### PR TITLE
CreateAndLaunch()にGameObject[]オーバーロードを追加

### DIFF
--- a/Assets/AirSticker/Runtime/Scripts/AirStickerProjector.cs
+++ b/Assets/AirSticker/Runtime/Scripts/AirStickerProjector.cs
@@ -326,13 +326,70 @@ namespace AirSticker.Runtime.Scripts
             float zOffsetInDecalSpace = 0.005f,
             int groupId = 0)
         {
+            return CreateAndLaunch(
+                owner,
+                new[] { receiverObject },
+                decalMaterial,
+                width,
+                height,
+                depth,
+                launchOnAwake,
+                onCompletedLaunch,
+                zOffsetInDecalSpace,
+                groupId);
+        }
+
+        /// <summary>
+        ///     Create and add AirStickerProjector to the GameObject.
+        /// </summary>
+        /// <remarks>
+        ///     This overload projects the decal onto multiple receiver objects at once,
+        ///     so a decal can be pasted across the boundary of the receivers. <br />
+        ///     One decal mesh is built per (receiver object, renderer, decal material, group ID),
+        ///     so the more receivers the decal spans, the more draw calls are made. <br />
+        ///     If any receiver's mesh is not Read/Write enabled, the launch is canceled at that receiver
+        ///     and the remaining receivers are not processed.
+        /// </remarks>
+        /// <param name="owner">Game object to which the component will be added.</param>
+        /// <param name="receiverObjects">Receiver objects to which decal is applied.</param>
+        /// <param name="decalMaterial">Decal material applied to receiver objects.</param>
+        /// <param name="width">Width of projector. It means to projection range.</param>
+        /// <param name="height">Height of projector. It means to projection range.</param>
+        /// <param name="depth">Depth of projector. It means to projection range.</param>
+        /// <param name="launchOnAwake">
+        ///     If it is true, the decal projection is started at same time as additional component.
+        ///     If it is false, the decal projection is started by explicitly calling the Launch method.
+        /// </param>
+        /// <param name="onCompletedLaunch">Callback function called when decal projection is complete.</param>
+        /// <param name="zOffsetInDecalSpace">The Z offset of the decal space from the receiver surface.</param>
+        /// <param name="groupId">
+        ///     The group ID of the decal mesh. <br />
+        ///     Decal meshes are shared only within the same group,
+        ///     so decals can be removed by group using the RemoveDecalMeshes method. <br />
+        ///     If it is not specified, the decal belongs to the group 0.
+        /// </param>
+        public static AirStickerProjector CreateAndLaunch(
+            GameObject owner,
+            GameObject[] receiverObjects,
+            Material decalMaterial,
+            float width,
+            float height,
+            float depth,
+            bool launchOnAwake,
+            UnityAction<State> onCompletedLaunch,
+            float zOffsetInDecalSpace = 0.005f,
+            int groupId = 0)
+        {
             var projector = owner.AddComponent<AirStickerProjector>();
             projector.width = width;
             projector.height = height;
             projector.depth = depth;
             projector.zOffsetInDecalSpace = zOffsetInDecalSpace;
-            projector.receiverObjects = new GameObject[1];
-            projector.receiverObjects[0] = receiverObject;
+            // Copy the array so that the caller mutating it during the multi-frame launch
+            // does not change the projection targets.
+            projector.receiverObjects = receiverObjects != null
+                ? (GameObject[])receiverObjects.Clone()
+                : null;
             projector.decalMaterial = decalMaterial;
             projector.groupId = groupId;
             projector.launchOnAwake = false;

--- a/Assets/Demo/Demo_05.meta
+++ b/Assets/Demo/Demo_05.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 401615c1fd994196ba77b654d73aaba9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Demo/Demo_05/Demo_05.unity
+++ b/Assets/Demo/Demo_05/Demo_05.unity
@@ -1,0 +1,744 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &100000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 100001}
+  - component: {fileID: 100002}
+  - component: {fileID: 100003}
+  - component: {fileID: 100004}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &100001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.25, z: -2.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!20 &100002
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 1
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!81 &100003
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+--- !u!114 &100004
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_TaaSettings:
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
+  m_Version: 2
+--- !u!1 &200000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 200001}
+  - component: {fileID: 200002}
+  - component: {fileID: 200003}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &200001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 200000}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!108 &200002
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 200000}
+  m_Enabled: 1
+  serializedVersion: 12
+  m_Type: 1
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize2D: {x: 10, y: 10}
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ForceVisible: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+  m_LightUnit: 1
+  m_LuxAtDistance: 1
+  m_EnableSpotReflector: 1
+--- !u!114 &200003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 200000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_UsePipelineSettings: 1
+  m_AdditionalLightsShadowResolutionTier: 2
+  m_CustomShadowLayers: 0
+  m_LightCookieSize: {x: 1, y: 1}
+  m_LightCookieOffset: {x: 0, y: 0}
+  m_SoftShadowQuality: 1
+  m_RenderingLayersMask:
+    serializedVersion: 0
+    m_Bits: 1
+  m_ShadowRenderingLayersMask:
+    serializedVersion: 0
+    m_Bits: 1
+  m_Version: 4
+  m_LightLayerMask: 1
+  m_ShadowLayerMask: 1
+  m_RenderingLayers: 1
+  m_ShadowRenderingLayers: 1
+--- !u!1 &300000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 300001}
+  - component: {fileID: 300002}
+  m_Layer: 0
+  m_Name: AirStickerSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &300001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 300000}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &300002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 300000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc3a9e683ad1f244caf92caffdec8c32, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+--- !u!1 &400000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 400001}
+  m_Layer: 0
+  m_Name: Receivers
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &400001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 400000}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 410001}
+  - {fileID: 420001}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &410000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 410001}
+  - component: {fileID: 410002}
+  - component: {fileID: 410003}
+  - component: {fileID: 410004}
+  m_Layer: 0
+  m_Name: WallLeft
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &410001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 410000}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1, y: 1.25, z: 1.5}
+  m_LocalScale: {x: 2, y: 2.5, z: 0.2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 400001}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &410002
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 410000}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &410003
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 410000}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 3619252ceb842b4429a74a8d12200d48, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &410004
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 410000}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &420000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 420001}
+  - component: {fileID: 420002}
+  - component: {fileID: 420003}
+  - component: {fileID: 420004}
+  m_Layer: 0
+  m_Name: WallRight
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &420001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 420000}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1, y: 1.25, z: 1.5}
+  m_LocalScale: {x: 2, y: 2.5, z: 0.2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 400001}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &420002
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 420000}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &420003
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 420000}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 4b2fd6932691cb4479696e0ddda3d64f, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &420004
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 420000}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &500000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 500001}
+  - component: {fileID: 500002}
+  m_Layer: 0
+  m_Name: Demo05
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &500001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 500000}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &500002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 500000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1544c07a708e4dbab79fdf805f4e531a, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  receiverObjects:
+  - {fileID: 410000}
+  - {fileID: 420000}
+  decalMaterial: {fileID: 2100000, guid: 434c39936d241ab45a19d599d9a2785a, type: 2}
+  projectorSize: {x: 0.6, y: 0.6, z: 1}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 100001}
+  - {fileID: 200001}
+  - {fileID: 300001}
+  - {fileID: 400001}
+  - {fileID: 500001}

--- a/Assets/Demo/Demo_05/Demo_05.unity.meta
+++ b/Assets/Demo/Demo_05/Demo_05.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 689eeff8458f42249453a0a7eb385000
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Demo/Demo_05/Scripts.meta
+++ b/Assets/Demo/Demo_05/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2f372d09daff4a5f9ebf9fc0ef196015
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Demo/Demo_05/Scripts/Demo05.cs
+++ b/Assets/Demo/Demo_05/Scripts/Demo05.cs
@@ -1,0 +1,95 @@
+using AirSticker.Runtime.Scripts;
+using UnityEngine;
+
+namespace Demo.Demo_05.Scripts
+{
+    /// <summary>
+    ///     Demo of pasting a decal across multiple receiver objects.
+    ///     Click near the boundary of the two walls to paste a sticker.
+    ///     Switch the mode with the GUI buttons to compare the multiple receivers overload
+    ///     (the sticker spans the boundary) with the single receiver overload
+    ///     (the sticker is cut at the boundary).
+    /// </summary>
+    public class Demo05 : MonoBehaviour
+    {
+        private const float GuiScale = 2.0f;
+        [SerializeField] private GameObject[] receiverObjects; // The receiver objects that the decal spans.
+        [SerializeField] private Material decalMaterial;
+        [SerializeField] private Vector3 projectorSize = new Vector3(0.6f, 0.6f, 1.0f);
+
+        private readonly Rect _panelRect = new Rect(10, 10, 280, 150);
+        private bool _useMultipleReceivers = true;
+
+        // The panel rect in actual screen coordinates, because OnGUI draws it scaled by GuiScale.
+        private Rect ScaledPanelRect => new Rect(
+            _panelRect.x * GuiScale,
+            _panelRect.y * GuiScale,
+            _panelRect.width * GuiScale,
+            _panelRect.height * GuiScale);
+
+        private void Update()
+        {
+            if (!Input.GetMouseButtonDown(0)) return;
+
+            // Ignore clicks on the GUI panel.
+            var guiPos = new Vector2(Input.mousePosition.x, Screen.height - Input.mousePosition.y);
+            if (ScaledPanelRect.Contains(guiPos)) return;
+
+            var ray = Camera.main.ScreenPointToRay(Input.mousePosition);
+            if (!Physics.Raycast(ray, out var hitInfo, 100.0f))
+            {
+                Debug.Log("Raycast miss");
+                return;
+            }
+
+            var projectorObject = new GameObject("Decal Projector");
+            // Install the projector at the position pushed back in the normal direction.
+            projectorObject.transform.position = hitInfo.point + hitInfo.normal * (projectorSize.z * 0.5f);
+            // Projector is oriented in the opposite direction of the normal.
+            projectorObject.transform.rotation = Quaternion.LookRotation(hitInfo.normal * -1.0f);
+
+            if (_useMultipleReceivers)
+                // The multiple receivers overload: the decal is projected onto all the receiver
+                // objects in the same decal space, so it spans the boundary of the walls.
+                AirStickerProjector.CreateAndLaunch(
+                    projectorObject,
+                    receiverObjects,
+                    decalMaterial,
+                    projectorSize.x,
+                    projectorSize.y,
+                    projectorSize.z,
+                    true,
+                    result => Destroy(projectorObject));
+            else
+                // The single receiver overload: only the clicked wall receives the decal,
+                // so the decal is cut at the boundary of the walls.
+                AirStickerProjector.CreateAndLaunch(
+                    projectorObject,
+                    hitInfo.collider.gameObject,
+                    decalMaterial,
+                    projectorSize.x,
+                    projectorSize.y,
+                    projectorSize.z,
+                    true,
+                    result => Destroy(projectorObject));
+        }
+
+        private void OnGUI()
+        {
+            // Scale up the whole GUI because the default IMGUI is too small to read.
+            GUI.matrix = Matrix4x4.Scale(new Vector3(GuiScale, GuiScale, 1.0f));
+            GUILayout.BeginArea(_panelRect, GUI.skin.box);
+            GUILayout.Label($"Mode : {(_useMultipleReceivers ? "Multiple Receivers" : "Single Receiver")}");
+            GUILayout.Label("Click near the boundary of the walls.");
+            if (GUILayout.Button("Multiple Receivers (spans the boundary)"))
+                _useMultipleReceivers = true;
+            if (GUILayout.Button("Single Receiver (cut at the boundary)"))
+                _useMultipleReceivers = false;
+
+            GUILayout.Space(10);
+            if (GUILayout.Button("Remove All Decals"))
+                AirStickerProjector.RemoveDecalMeshes(0);
+            GUILayout.EndArea();
+        }
+    }
+}

--- a/Assets/Demo/Demo_05/Scripts/Demo05.cs.meta
+++ b/Assets/Demo/Demo_05/Scripts/Demo05.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1544c07a708e4dbab79fdf805f4e531a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/TestCreateAndLaunch.cs
+++ b/Assets/Tests/TestCreateAndLaunch.cs
@@ -1,0 +1,125 @@
+using AirSticker.Runtime.Scripts;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+
+namespace Tests
+{
+    public class TestCreateAndLaunch
+    {
+        private static GameObject[] GetSerializedReceiverObjects(AirStickerProjector projector)
+        {
+            var serializedObject = new SerializedObject(projector);
+            var property = serializedObject.FindProperty("receiverObjects");
+            var receiverObjects = new GameObject[property.arraySize];
+            for (var i = 0; i < property.arraySize; i++)
+                receiverObjects[i] = property.GetArrayElementAtIndex(i).objectReferenceValue as GameObject;
+            return receiverObjects;
+        }
+
+        [Test]
+        public void TestSingleReceiverOverload()
+        {
+            var owner = new GameObject("Owner");
+            var receiverObject = new GameObject("ReceiverObject");
+            var decalMaterial = new Material(Shader.Find("Hidden/InternalErrorShader"));
+
+            try
+            {
+                var projector = AirStickerProjector.CreateAndLaunch(
+                    owner,
+                    receiverObject,
+                    decalMaterial,
+                    1.0f,
+                    1.0f,
+                    1.0f,
+                    false,
+                    null);
+
+                Assert.AreEqual(AirStickerProjector.State.NotLaunch, projector.NowState);
+                var receiverObjects = GetSerializedReceiverObjects(projector);
+                Assert.AreEqual(1, receiverObjects.Length);
+                Assert.AreEqual(receiverObject, receiverObjects[0]);
+            }
+            finally
+            {
+                Object.DestroyImmediate(decalMaterial);
+                Object.DestroyImmediate(receiverObject);
+                Object.DestroyImmediate(owner);
+            }
+        }
+
+        [Test]
+        public void TestMultipleReceiversOverload()
+        {
+            var owner = new GameObject("Owner");
+            var receiverObjectA = new GameObject("ReceiverObjectA");
+            var receiverObjectB = new GameObject("ReceiverObjectB");
+            var decalMaterial = new Material(Shader.Find("Hidden/InternalErrorShader"));
+
+            try
+            {
+                var projector = AirStickerProjector.CreateAndLaunch(
+                    owner,
+                    new[] { receiverObjectA, receiverObjectB },
+                    decalMaterial,
+                    1.0f,
+                    1.0f,
+                    1.0f,
+                    false,
+                    null);
+
+                Assert.AreEqual(AirStickerProjector.State.NotLaunch, projector.NowState);
+                var receiverObjects = GetSerializedReceiverObjects(projector);
+                Assert.AreEqual(2, receiverObjects.Length);
+                Assert.AreEqual(receiverObjectA, receiverObjects[0]);
+                Assert.AreEqual(receiverObjectB, receiverObjects[1]);
+            }
+            finally
+            {
+                Object.DestroyImmediate(decalMaterial);
+                Object.DestroyImmediate(receiverObjectB);
+                Object.DestroyImmediate(receiverObjectA);
+                Object.DestroyImmediate(owner);
+            }
+        }
+
+        [Test]
+        public void TestReceiverObjectsArrayIsCopied()
+        {
+            var owner = new GameObject("Owner");
+            var receiverObjectA = new GameObject("ReceiverObjectA");
+            var receiverObjectB = new GameObject("ReceiverObjectB");
+            var decalMaterial = new Material(Shader.Find("Hidden/InternalErrorShader"));
+
+            try
+            {
+                var callerArray = new[] { receiverObjectA };
+                var projector = AirStickerProjector.CreateAndLaunch(
+                    owner,
+                    callerArray,
+                    decalMaterial,
+                    1.0f,
+                    1.0f,
+                    1.0f,
+                    false,
+                    null);
+
+                // Mutating the caller's array must not change the projection targets,
+                // because the launch runs over multiple frames.
+                callerArray[0] = receiverObjectB;
+
+                var receiverObjects = GetSerializedReceiverObjects(projector);
+                Assert.AreEqual(1, receiverObjects.Length);
+                Assert.AreEqual(receiverObjectA, receiverObjects[0]);
+            }
+            finally
+            {
+                Object.DestroyImmediate(decalMaterial);
+                Object.DestroyImmediate(receiverObjectB);
+                Object.DestroyImmediate(receiverObjectA);
+                Object.DestroyImmediate(owner);
+            }
+        }
+    }
+}

--- a/Assets/Tests/TestCreateAndLaunch.cs.meta
+++ b/Assets/Tests/TestCreateAndLaunch.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 50ee43537dca5a84d8833eb54610186f

--- a/README.md
+++ b/README.md
@@ -213,6 +213,23 @@ void LaunchProjector(
                     /*onCompletedLaunch*/() => { Destroy(projectorObj); });
 }
 ```
+
+If you want to paste a single decal across multiple receiver objects, use the overload of the CreateAndLaunch() method that takes an array of receiver objects.<br/>
+The decal is projected onto all the receiver objects in the same decal space, so the decal texture is continuous across the boundary of the receivers.<br/>
+```C#
+AirStickerProjector.CreateAndLaunch(
+                projectorObj,
+                /*receiverObjects*/new[] { receiverObjectA, receiverObjectB },
+                decalMaterial,
+                /*width=*/0.05f,
+                /*height=*/0.05f,
+                /*depth=*/0.2f,
+                /*launchOnAwake*/true,
+                /*onCompletedLaunch*/result => { Destroy(projectorObj); });
+```
+One decal mesh is built per receiver object (per renderer and decal material), so the more receiver objects the decal spans, the more draw calls are made.<br/>
+Note that if any receiver's mesh is not Read/Write enabled, the launch is canceled at that receiver and the remaining receiver objects are not processed.<br/>
+
 ***
 <p align="right">
 © Unity Technologies Japan/UC

--- a/README_JA.md
+++ b/README_JA.md
@@ -208,6 +208,22 @@ void LaunchProjector(
 }
 ```
 
+複数のレシーバーオブジェクトに跨って1つのデカールを貼り付けたい場合は、レシーバーオブジェクトの配列を受け取るCreateAndLaunch()メソッドのオーバーロードを使用してください。<br/>
+全てのレシーバーオブジェクトに同一のデカール空間で投影されるため、レシーバーの境目でもデカールのテクスチャは連続します。<br/>
+```C#
+AirStickerProjector.CreateAndLaunch(
+                projectorObj,
+                /*receiverObjects*/new[] { receiverObjectA, receiverObjectB },
+                decalMaterial,
+                /*width=*/0.05f,
+                /*height=*/0.05f,
+                /*depth=*/0.2f,
+                /*launchOnAwake*/true,
+                /*onCompletedLaunch*/result => { Destroy(projectorObj); });
+```
+デカールメッシュはレシーバーオブジェクトごと(さらにレンダラー・デカールマテリアルごと)に構築されるため、跨るレシーバーの数だけドローコールは増えます。<br/>
+また、いずれかのレシーバーのメッシュがRead/Write有効になっていない場合、そのレシーバーの時点で投影はキャンセルされ、残りのレシーバーオブジェクトは処理されません。<br/>
+
 ***
 <p align="right">
 © Unity Technologies Japan/UC


### PR DESCRIPTION
## 概要

複数のレシーバーオブジェクトに跨ってデカールを貼るケースで、ランタイム生成 API(`CreateAndLaunch()`)が単一レシーバーしか受け取れなかった制限を解消します。

投影パイプライン(`ExecuteLaunch()`)は元々 `receiverObjects` 配列をループする複数レシーバー対応済みで、インスペクタ配置では複数指定が可能でした。`CreateAndLaunch()` だけが長さ1の配列を固定生成していたため、ランタイム生成では利用できませんでした。

## 変更内容

- `CreateAndLaunch()` に `GameObject[]` を受け取るオーバーロードを追加
  - 既存の単体版は `new[] { receiverObject }` で配列版へ委譲(後方互換維持)
  - 渡された配列は防御的コピーし、数フレームかかる Launch 中に呼び出し側が配列を書き換えても投影対象が変わらないようにする
- EditMode テスト追加(`TestCreateAndLaunch`: 委譲の互換性・全要素の設定・防御的コピー)
- README EN/JA に複数レシーバーオーバーロードの説明とサンプルを追記
- **Demo_05 追加**: マテリアルの異なる2枚の壁の継ぎ目にステッカーを貼るデモ。GUI で「Multiple Receivers(継ぎ目を跨いで連続)」と「Single Receiver(継ぎ目で切れる)」を切り替えて比較できる

## 動作仕様

- 各レシーバーは同一のデカール空間でクリップされ UV もデカール空間基準のため、レシーバーの境目でテクスチャは連続する
- デカールメッシュはレシーバー(×レンダラー×マテリアル×グループID)ごとに構築されるため、跨るレシーバーの数だけドローコールは増える
- いずれかのレシーバーのメッシュが Read/Write 無効の場合、そのレシーバーの時点で `LaunchingCanceled` となり残りは処理されない(インスペクタで複数指定した場合の現行挙動と同一)

## 既知の制限

receiver 引数に `null` **リテラル**を直渡しする既存コードはオーバーロード解決が曖昧になりコンパイルエラーになります(変数経由の呼び出しは影響なし。`(GameObject)null` キャストで回避可能)。null レシーバー指定は何も焼かれない実質無意味な呼び出しのため、許容と判断しました。

## 確認

- [x] MSBuild で AirSticker / Tests / Assembly-CSharp のコンパイル確認
- [x] Demo_05 の Play モードで、複数レシーバー版が継ぎ目を跨いで連続すること・単体版が継ぎ目で切れることを目視確認
- [x] Test Runner での EditMode テスト実行(レビュー時にご確認ください)

🤖 Generated with [Claude Code](https://claude.com/claude-code)