### PR TITLE
Air Sticker 2.1.0 リリース準備

### DIFF
--- a/Assets/AirSticker/CHANGELOG.md
+++ b/Assets/AirSticker/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this package are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2026-08-03
+
+### Added
+
+- `AirStickerProjector.CreateAndLaunch()` overload that takes an array of receiver objects
+  (`GameObject[]`), so a decal created at runtime can span the boundary of multiple receiver
+  objects. All receivers are clipped in the same decal space, so the decal texture is
+  continuous across the boundary. One decal mesh is built per receiver (per renderer and
+  decal material), so the more receivers the decal spans, the more draw calls are made.
+  The single-receiver overload is unchanged and delegates to the new one.
+- Demo_05: click near the boundary of two walls and compare the multiple receivers overload
+  (the sticker spans the boundary) with the single receiver overload (the sticker is cut at
+  the boundary).
+
+### Known limitations
+
+- Call sites passing a `null` literal as the receiver argument of `CreateAndLaunch()` no
+  longer compile because the call is ambiguous between the two overloads. Cast to
+  `(GameObject)null` if needed (such a call pastes nothing); calls passing a
+  `GameObject`-typed variable are unaffected.
+
 ## [2.0.0] - 2026-07-31
 
 Decal mesh generation was rewritten on the Unity Job System + Burst. This is a major

--- a/Assets/AirSticker/package.json
+++ b/Assets/AirSticker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jp.co.cyberagent.air-sticker",
   "displayName": "Air Sticker",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "unity": "6000.0",
   "license": "MIT",
   "dependencies": {

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Or, open `Packages/manifest.json` and add the following to the dependencies bloc
 
 If you want to set the target version, write as follows.
 
-* https://github.com/CyberAgentGameEntertainment/AirSticker.git?path=/Assets/AirSticker#2.0.0
+* https://github.com/CyberAgentGameEntertainment/AirSticker.git?path=/Assets/AirSticker#2.1.0
 
 Note that if you get a message like `No 'git' executable was found. Please install Git on your system and restart Unity`, you will need to set up Git on your machine.
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -112,7 +112,7 @@ Air Stickerはメッシュ生成に数フレームかかりますが、描画パ
 
 バージョンを指定したい場合には以下のように記述します。
 
-* https://github.com/CyberAgentGameEntertainment/AirSticker.git?path=/Assets/AirSticker#2.0.0
+* https://github.com/CyberAgentGameEntertainment/AirSticker.git?path=/Assets/AirSticker#2.1.0
 
 なお`No 'git' executable was found. Please install Git on your system and restart Unity`のようなメッセージが出た場合、マシンにGitをセットアップする必要がある点にご注意ください。
 


### PR DESCRIPTION
## 概要

#37(`CreateAndLaunch()` の `GameObject[]` オーバーロード追加)を含む **2.1.0** のリリース準備です。後方互換の機能追加のためマイナーバンプです。

## 変更内容

- `Assets/AirSticker/package.json` の `version` を `2.0.0` → `2.1.0`
- `CHANGELOG.md` に 2.1.0 エントリを追加
  - Added: 複数レシーバーオーバーロード(同一デカール空間で投影されるため境目でテクスチャが連続する点、レシーバー数ぶんドローコールが増える点を記載)、Demo_05
  - Known limitations: receiver 引数への `null` リテラル直渡しがオーバーロード解決の曖昧化でコンパイルエラーになる点
- README EN/JA のバージョン指定インストール例を `#2.1.0` へ更新

## マージ後の作業

- [x] `2.1.0` タグを main のマージコミットに打って push(UPM の git URL 参照用)

🤖 Generated with [Claude Code](https://claude.com/claude-code)