### PR TITLE
毎フレーム発生していたGC.Allocを削除

### DIFF
--- a/Assets/AirSticker/Runtime/Scripts/Core/DecalMeshPool.cs
+++ b/Assets/AirSticker/Runtime/Scripts/Core/DecalMeshPool.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
 
 namespace AirSticker.Runtime.Scripts.Core
@@ -22,6 +21,13 @@ namespace AirSticker.Runtime.Scripts.Core
     public sealed class DecalMeshPool : IDecalMeshPool
     {
         private readonly Dictionary<int, DecalMesh> _decalMeshes = new Dictionary<int, DecalMesh>();
+
+        // The hashes to remove in the current call. They are reused across calls because GarbageCollect
+        // runs every frame, so allocating a list per call would produce constant GC garbage. The two
+        // methods keep their own list so a removal requested by the user cannot disturb a running
+        // garbage collection.
+        private readonly List<int> _garbageCollectHashes = new List<int>();
+        private readonly List<int> _removeHashes = new List<int>();
 
         public int GetPoolSize()
         {
@@ -86,13 +92,21 @@ namespace AirSticker.Runtime.Scripts.Core
         /// </summary>
         void IDecalMeshPool.GarbageCollect()
         {
-            // Create deletable list.
-            var removeList = _decalMeshes.Where(item => item.Value.CanRemoveFromPool()).ToList();
-            foreach (var item in removeList)
+            // Gather the deletable hashes into the reused list. The dictionary is enumerated directly (its
+            // enumerator is a struct) because entries cannot be removed while enumerating. Doing this with
+            // LINQ would allocate every frame even when there is nothing to remove.
+            foreach (var item in _decalMeshes)
+                if (item.Value.CanRemoveFromPool())
+                    _garbageCollectHashes.Add(item.Key);
+
+            for (var i = 0; i < _garbageCollectHashes.Count; i++)
             {
-                item.Value.Dispose();
-                _decalMeshes.Remove(item.Key);
+                var hash = _garbageCollectHashes[i];
+                if (_decalMeshes.TryGetValue(hash, out var decalMesh)) decalMesh.Dispose();
+                _decalMeshes.Remove(hash);
             }
+
+            _garbageCollectHashes.Clear();
         }
 
         /// <summary>
@@ -114,16 +128,25 @@ namespace AirSticker.Runtime.Scripts.Core
             GameObject receiverObject = null,
             Material decalMaterial = null)
         {
-            var removeList = _decalMeshes.Where(item =>
-                item.Value.GroupId == groupId
-                && (receiverObject == null || item.Value.ReceiverObject == receiverObject)
-                && (decalMaterial == null || item.Value.DecalMaterial == decalMaterial)).ToList();
-            foreach (var item in removeList)
+            foreach (var item in _decalMeshes)
+                if (item.Value.GroupId == groupId
+                    && (receiverObject == null || item.Value.ReceiverObject == receiverObject)
+                    && (decalMaterial == null || item.Value.DecalMaterial == decalMaterial))
+                    _removeHashes.Add(item.Key);
+
+            for (var i = 0; i < _removeHashes.Count; i++)
             {
-                item.Value.DestroyDecalMeshRenderer();
-                item.Value.Dispose();
-                _decalMeshes.Remove(item.Key);
+                var hash = _removeHashes[i];
+                if (_decalMeshes.TryGetValue(hash, out var decalMesh))
+                {
+                    decalMesh.DestroyDecalMeshRenderer();
+                    decalMesh.Dispose();
+                }
+
+                _decalMeshes.Remove(hash);
             }
+
+            _removeHashes.Clear();
         }
 
         /// <summary>

--- a/Assets/AirSticker/Runtime/Scripts/Core/ReceiverObjectTrianglePolygonsPool.cs
+++ b/Assets/AirSticker/Runtime/Scripts/Core/ReceiverObjectTrianglePolygonsPool.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using AirSticker.Runtime.Scripts.Core.Jobs;
 using UnityEngine;
 
@@ -28,6 +27,10 @@ namespace AirSticker.Runtime.Scripts.Core
         private readonly Dictionary<GameObject, ReceiverConvexPolygonsMesh> _trianglePolygonsPool =
             new Dictionary<GameObject, ReceiverConvexPolygonsMesh>();
 
+        // The keys to delete in the current GarbageCollect call. It is reused across calls because
+        // GarbageCollect runs every frame, so allocating a list per call would produce constant GC garbage.
+        private readonly List<GameObject> _deleteKeys = new List<GameObject>();
+
         IReadOnlyDictionary<GameObject, ReceiverConvexPolygonsMesh> IReceiverObjectTrianglePolygonsPool.Pool =>
             _trianglePolygonsPool;
 
@@ -47,13 +50,21 @@ namespace AirSticker.Runtime.Scripts.Core
         {
             // A mesh whose jobs are still running (InUse) is kept even if its receiver died, so the jobs
             // never read freed NativeArrays; a later GarbageCollect disposes it once InUse is cleared.
-            var deleteList = _trianglePolygonsPool
-                .Where(item => item.Key == null && (item.Value == null || !item.Value.InUse)).ToList();
-            foreach (var item in deleteList)
+            // The dictionary is enumerated directly (its enumerator is a struct) and the dead keys are
+            // gathered into the reused list, because entries cannot be removed while enumerating. Doing
+            // this with LINQ would allocate every frame even when there is nothing to delete.
+            foreach (var item in _trianglePolygonsPool)
+                if (item.Key == null && (item.Value == null || !item.Value.InUse))
+                    _deleteKeys.Add(item.Key);
+
+            for (var i = 0; i < _deleteKeys.Count; i++)
             {
-                item.Value?.Dispose();
-                _trianglePolygonsPool.Remove(item.Key);
+                var key = _deleteKeys[i];
+                if (_trianglePolygonsPool.TryGetValue(key, out var mesh)) mesh?.Dispose();
+                _trianglePolygonsPool.Remove(key);
             }
+
+            _deleteKeys.Clear();
         }
 
         void IReceiverObjectTrianglePolygonsPool.DisposeAll()


### PR DESCRIPTION
## 概要

`AirStickerSystem.Update()` から毎フレーム呼ばれるプール2種の `GarbageCollect()` が、常時 320B/フレームの GC.Alloc を発生させていたので削除しました。

## 原因

`DecalMeshPool.GarbageCollect()` と `ReceiverObjectTrianglePolygonsPool.GarbageCollect()` は、どちらも `Dictionary.Where(...).ToList()` で削除対象を集めていました。この書き方は**削除対象が0件でも1回あたり3個**を確保します。

| 確保されるもの | 内容 |
| --- | --- |
| `WhereEnumerableIterator<KeyValuePair<…>>` | `Where()` が返す LINQ イテレータ本体 |
| boxing された `Dictionary<,>.Enumerator` | `Where()` が `IEnumerable<T>.GetEnumerator()` を呼ぶため、構造体 Enumerator がヒープに箱詰めされる |
| `List<KeyValuePair<…>>` | `ToList()` |

これが毎フレーム2箇所で走り、Profiler の `AirStickerSystem.Update()` に **GC.Alloc 6回 / 320 B** として出ていました（回数も内訳と一致）。ラムダ自体はキャプチャなしで静的キャッシュされるため無害でした。

## 変更内容

- 削除対象を集めるリストをフィールドに持って再利用し、Dictionary を具象型のまま `foreach` する（構造体 Enumerator が使われ boxing が起きない）形に置き換えました。列挙中は `Remove` できないため、キー収集 → 削除の2パス構成は維持しています。
- `RemoveDecalMeshes()` も同じ形に置き換えました。毎フレーム実行ではありませんが、ラムダが `groupId` / `receiverObject` / `decalMaterial` をキャプチャするためクロージャとデリゲートまで確保しており、デカール削除を頻繁に呼ぶ使い方で効きます。GC 中のリストを乱さないよう、リストは `GarbageCollect()` とは別フィールドにしています。
- 上記により LINQ が不要になったため、両ファイルから `using System.Linq;` を削除しました。

削除判定・`Dispose` の順序・`InUse` のスキップ条件は変更しておらず、挙動は同一です。

## 確認したこと

- `AirSticker.csproj` / `Tests.csproj` を MSBuild でビルドし、エラー・新規警告なし。
- エディタの Profiler (Deep Profile) で `AirStickerSystem.Update()` の GC.Alloc が消えていることを確認済み。
- ライブラリ側で毎フレーム走るのは `AirStickerSystem.Update()` のみ（他に `Update` / `LateUpdate` を持つクラスは無し）なので、定常状態の GC.Alloc はこれで 0 になります。

## 残課題（本PRの対象外）

launch 1回あたりのアロケーションは残っています。

- `AirStickerProjector.ExecuteLaunch()` の `.Where(s => s.name != "AirStickerRenderer").ToArray()` — `s.name` は呼ぶたびに string を確保するため、名前比較ではなく専用コンポーネントでの判定が望ましい
- `DecalMeshPool.CalculateHash()` の文字列補間 — `HashCode.Combine` に置き換えれば 0 alloc かつ衝突耐性も向上
- receiver ごとの `new List<DecalMesh>()` / `GetComponentsInChildren` 配列 — `GetComponentsInChildren(List<T>)` オーバーロードと使い回しリストで削減可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)
