### PR TITLE
decal貼り付け開始フレームのGC.Allocを削除

### DIFF
--- a/Assets/AirSticker/Runtime/Scripts/AirStickerProjector.cs
+++ b/Assets/AirSticker/Runtime/Scripts/AirStickerProjector.cs
@@ -1,6 +1,5 @@
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using AirSticker.Runtime.Scripts.Core;
 using AirSticker.Runtime.Scripts.Core.Jobs;
 using Unity.Jobs;
@@ -65,6 +64,16 @@ namespace AirSticker.Runtime.Scripts
         // disposes it from here to avoid leaking its Persistent NativeArrays. Only one extraction is in flight
         // at a time, and the holder is cleared as soon as the source is registered.
         private readonly ReceiverConvexPolygonsMesh[] _pendingSourceHolder = new ReceiverConvexPolygonsMesh[1];
+
+        // The working lists of ExecuteLaunch, kept as fields so the launch does not allocate a list (or an
+        // array from GetComponentsInChildren) per receiver object. The renderer/terrain lists are held across
+        // the frame-sliced extraction, so they belong to the projector instance rather than being shared by
+        // AirStickerSystem: a list shared between projectors would be refilled by the next launch while this
+        // one is still reading it.
+        private readonly List<DecalMesh> _receiverDecalMeshes = new List<DecalMesh>();
+        private readonly List<MeshRenderer> _meshRenderers = new List<MeshRenderer>();
+        private readonly List<SkinnedMeshRenderer> _skinnedMeshRenderers = new List<SkinnedMeshRenderer>();
+        private readonly List<Terrain> _terrains = new List<Terrain>();
 
         /// <summary>
         ///     True while this projector's jobs are scheduled and not yet completed.
@@ -156,6 +165,10 @@ namespace AirSticker.Runtime.Scripts
 
         private void OnFinished(State finishedState)
         {
+            // The launch is over (completed, canceled or destroyed), so the reused working lists must not keep
+            // the receiver's renderers alive until the next launch.
+            ClearWorkingLists();
+
             if (onFinishedLaunch == null) return;
 
             onFinishedLaunch.Invoke(finishedState);
@@ -178,13 +191,13 @@ namespace AirSticker.Runtime.Scripts
             {
                 if (receiverObject == null || !receiverObject) continue;
 
-                var receiverDecalMeshes = new List<DecalMesh>();
-                AirStickerSystem.CollectEditDecalMeshes(receiverDecalMeshes, receiverObject, decalMaterial, groupId);
-                DecalMeshes.AddRange(receiverDecalMeshes);
+                _receiverDecalMeshes.Clear();
+                AirStickerSystem.CollectEditDecalMeshes(_receiverDecalMeshes, receiverObject, decalMaterial, groupId);
+                DecalMeshes.AddRange(_receiverDecalMeshes);
 
-                var skinnedMeshRenderers = receiverObject.GetComponentsInChildren<SkinnedMeshRenderer>()
-                    .Where(s => s.name != "AirStickerRenderer").ToArray();
-                var terrains = receiverObject.GetComponentsInChildren<Terrain>();
+                receiverObject.GetComponentsInChildren(false, _skinnedMeshRenderers);
+                ExcludeDecalMeshRenderers(_skinnedMeshRenderers);
+                receiverObject.GetComponentsInChildren(false, _terrains);
 
                 if (AirStickerSystem.ReceiverObjectTrianglePolygonsPool.Contains(receiverObject) == false)
                 {
@@ -192,10 +205,11 @@ namespace AirSticker.Runtime.Scripts
                     // tracked in _pendingSourceHolder so OnDestroy can dispose it if this projector is destroyed
                     // mid-extraction, before it is registered into the pool below.
                     _pendingSourceHolder[0] = null;
+                    receiverObject.GetComponentsInChildren(false, _meshRenderers);
                     yield return AirStickerSystem.BuildTrianglePolygonsFromReceiverObject(
-                        receiverObject.GetComponentsInChildren<MeshRenderer>(),
-                        skinnedMeshRenderers,
-                        terrains,
+                        _meshRenderers,
+                        _skinnedMeshRenderers,
+                        _terrains,
                         _pendingSourceHolder);
 
                     if (_pendingSourceHolder[0] == null)
@@ -251,7 +265,7 @@ namespace AirSticker.Runtime.Scripts
                 }
 
                 // Main-thread step between the segments: size the output from the clip result.
-                pipeline.CountBuild(source, receiverDecalMeshes);
+                pipeline.CountBuild(source, _receiverDecalMeshes);
 
                 // Segment 2: build the appended geometry (serial job, off the main thread).
                 _currentJobHandle = pipeline.ScheduleBuildStage(
@@ -264,12 +278,42 @@ namespace AirSticker.Runtime.Scripts
                 _currentSource = null;
 
                 // Merge the built geometry into the decal meshes and upload them (main thread).
-                pipeline.ApplyToDecalMeshes(receiverDecalMeshes);
-                foreach (var decalMesh in receiverDecalMeshes) decalMesh.ExecutePostProcessingAfterWorkerThread();
+                pipeline.ApplyToDecalMeshes(_receiverDecalMeshes);
+                foreach (var decalMesh in _receiverDecalMeshes) decalMesh.ExecutePostProcessingAfterWorkerThread();
             }
 
             OnFinished(State.LaunchingCompleted);
             yield return null;
+        }
+
+        /// <summary>
+        ///     Drop the decal renderers that hang under the receiver object, so they are not gathered as
+        ///     receivers themselves. They are identified by <see cref="DecalMeshRendererMarker" />; see that
+        ///     class for why the GameObject's name is not used.
+        /// </summary>
+        private static void ExcludeDecalMeshRenderers<T>(List<T> renderers) where T : Component
+        {
+            // Compacted in place so that neither the filtering nor the removal allocates.
+            var writeNo = 0;
+            for (var readNo = 0; readNo < renderers.Count; readNo++)
+            {
+                var renderer = renderers[readNo];
+                if (renderer.TryGetComponent<DecalMeshRendererMarker>(out _)) continue;
+                renderers[writeNo++] = renderer;
+            }
+
+            renderers.RemoveRange(writeNo, renderers.Count - writeNo);
+        }
+
+        /// <summary>
+        ///     Release the receivers held by the reused working lists once the launch no longer needs them.
+        /// </summary>
+        private void ClearWorkingLists()
+        {
+            _receiverDecalMeshes.Clear();
+            _meshRenderers.Clear();
+            _skinnedMeshRenderers.Clear();
+            _terrains.Clear();
         }
 
         /// <summary>
@@ -442,16 +486,24 @@ namespace AirSticker.Runtime.Scripts
             NowState = State.Launching;
             if (onFinishedLaunch != null) this.onFinishedLaunch.AddListener(onFinishedLaunch);
             // Request the launching of the decal.
-            AirStickerSystem.DecalProjectorLauncher.Request(
-                this,
-                () =>
-                {
-                    if (receiverObjects != null)
-                        StartCoroutine(ExecuteLaunch());
-                    else
-                        // Receiver object has been dead, so process is terminated.
-                        OnFinished(State.LaunchingCanceled);
-                });
+            AirStickerSystem.DecalProjectorLauncher.Request(this);
+        }
+
+        /// <summary>
+        ///     Start this projector's launch. Called by the launcher when the queued request reaches the front
+        ///     of the queue.
+        /// </summary>
+        /// <remarks>
+        ///     This is a method instead of a callback handed to <c>Request</c>, because a lambda there
+        ///     allocated a delegate for every decal.
+        /// </remarks>
+        internal void OnLaunchRequestAccepted()
+        {
+            if (receiverObjects != null)
+                StartCoroutine(ExecuteLaunch());
+            else
+                // Receiver object has been dead, so process is terminated.
+                OnFinished(State.LaunchingCanceled);
         }
 
         private void InitializeOriginAxisInDecalSpace()

--- a/Assets/AirSticker/Runtime/Scripts/AirStickerSystem.cs
+++ b/Assets/AirSticker/Runtime/Scripts/AirStickerSystem.cs
@@ -22,6 +22,12 @@ namespace AirSticker.Runtime.Scripts
         private readonly IReceiverObjectTrianglePolygonsPool _receiverObjectTrianglePolygonsPool =
             new ReceiverObjectTrianglePolygonsPool();
 
+        // The working lists of CollectEditDecalMeshes, reused so that gathering the receiver's renderers does
+        // not allocate an array per launch. The method does not yield and only one launch runs at a time, so
+        // the lists are never read across calls.
+        private readonly List<Renderer> _collectedRenderers = new List<Renderer>();
+        private readonly List<Terrain> _collectedTerrains = new List<Terrain>();
+
         private TrianglePolygonsFactory _trianglePolygonsFactory;
         private DecalMeshJobPipeline _jobPipeline;
 
@@ -85,9 +91,9 @@ namespace AirSticker.Runtime.Scripts
         }
 
         internal static IEnumerator BuildTrianglePolygonsFromReceiverObject(
-            MeshRenderer[] meshRenderers,
-            SkinnedMeshRenderer[] skinnedMeshRenderers,
-            Terrain[] terrains,
+            IReadOnlyList<MeshRenderer> meshRenderers,
+            IReadOnlyList<SkinnedMeshRenderer> skinnedMeshRenderers,
+            IReadOnlyList<Terrain> terrains,
             ReceiverConvexPolygonsMesh[] resultHolder)
         {
             yield return Instance._trianglePolygonsFactory.BuildFromReceiverObject(
@@ -114,7 +120,8 @@ namespace AirSticker.Runtime.Scripts
             // But the renderer of decal mesh hanging from receiver object.
             // Therefore, temporarily disable to the renderer of decal mesh.
             Instance._decalMeshPool.DisableDecalMeshRenderers();
-            var renderers = receiverObject.GetComponentsInChildren<Renderer>();
+            var renderers = Instance._collectedRenderers;
+            receiverObject.GetComponentsInChildren(false, renderers);
             foreach (var renderer in renderers)
             {
                 if (!renderer) return;
@@ -133,7 +140,8 @@ namespace AirSticker.Runtime.Scripts
                 }
             }
 
-            var terrains = receiverObject.GetComponentsInChildren<Terrain>();
+            var terrains = Instance._collectedTerrains;
+            receiverObject.GetComponentsInChildren(false, terrains);
             foreach (var terrain in terrains)
             {
                 if (!terrain) return;

--- a/Assets/AirSticker/Runtime/Scripts/Core/DecalMeshPool.cs
+++ b/Assets/AirSticker/Runtime/Scripts/Core/DecalMeshPool.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -157,8 +158,14 @@ namespace AirSticker.Runtime.Scripts.Core
         {
             // Use instance IDs instead of names, because different objects can have the same name
             // (e.g. clones of the same prefab) and must not share a decal mesh.
-            var key = $"{receiverObject.GetInstanceID()}_{decalMaterial.GetInstanceID()}_{component.GetInstanceID()}_{groupId}";
-            return key.GetHashCode();
+            // The IDs are combined with HashCode instead of being formatted into a string, because this is
+            // called once per renderer of the receiver object on every launch and the string interpolation
+            // allocated for each of them.
+            return HashCode.Combine(
+                receiverObject.GetInstanceID(),
+                decalMaterial.GetInstanceID(),
+                component.GetInstanceID(),
+                groupId);
         }
     }
 }

--- a/Assets/AirSticker/Runtime/Scripts/Core/DecalMeshRenderer.cs
+++ b/Assets/AirSticker/Runtime/Scripts/Core/DecalMeshRenderer.cs
@@ -8,6 +8,9 @@ namespace AirSticker.Runtime.Scripts.Core
         public DecalMeshRenderer(Component receiverComponent, Material decalMaterial, Mesh mesh)
         {
             Owner = new GameObject("AirStickerRenderer");
+            // Let the projector recognize this renderer without touching GameObject.name (see
+            // DecalMeshRendererMarker).
+            Owner.AddComponent<DecalMeshRendererMarker>();
             if (receiverComponent is MeshRenderer || receiverComponent is Terrain)
             {
                 var meshRenderer = Owner.AddComponent<MeshRenderer>();

--- a/Assets/AirSticker/Runtime/Scripts/Core/DecalMeshRendererMarker.cs
+++ b/Assets/AirSticker/Runtime/Scripts/Core/DecalMeshRendererMarker.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+
+namespace AirSticker.Runtime.Scripts.Core
+{
+    /// <summary>
+    ///     Marks the GameObject spawned by <see cref="DecalMeshRenderer" /> as a decal renderer.
+    /// </summary>
+    /// <remarks>
+    ///     The projector gathers the receiver's renderers with GetComponentsInChildren, which also picks up the
+    ///     decal renderers hanging under the receiver. They are identified by this component instead of by the
+    ///     GameObject's name, because Renderer.name allocates a string on every access and the check runs once
+    ///     per renderer on every launch. The GameObject is still named "AirStickerRenderer" so that it stays
+    ///     recognizable in the hierarchy and to user code.
+    /// </remarks>
+    [DisallowMultipleComponent]
+    internal sealed class DecalMeshRendererMarker : MonoBehaviour
+    {
+    }
+}

--- a/Assets/AirSticker/Runtime/Scripts/Core/DecalMeshRendererMarker.cs.meta
+++ b/Assets/AirSticker/Runtime/Scripts/Core/DecalMeshRendererMarker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3c9f1b7a4e2d40a5b8c6d1e7f0a29b34
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AirSticker/Runtime/Scripts/Core/DecalProjectorLauncher.cs
+++ b/Assets/AirSticker/Runtime/Scripts/Core/DecalProjectorLauncher.cs
@@ -19,6 +19,7 @@ namespace AirSticker.Runtime.Scripts.Core
     {
         private readonly Queue<LaunchRequest> _launchRequestQueues = new Queue<LaunchRequest>();
         private LaunchRequest _currentRequest;
+        private bool _hasCurrentRequest;
 
         void IDecalProjectorLauncher.Update()
         {
@@ -32,6 +33,19 @@ namespace AirSticker.Runtime.Scripts.Core
         /// <summary>
         ///     Queueing startup requests to the queue.
         /// </summary>
+        /// <remarks>
+        ///     The projector's own launch method is called when the request is processed, so no callback has
+        ///     to be allocated per decal. <see cref="Request(AirStickerProjector, Action)" /> remains for
+        ///     callers that need a custom callback.
+        /// </remarks>
+        internal void Request(AirStickerProjector projector)
+        {
+            _launchRequestQueues.Enqueue(new LaunchRequest(projector, null));
+        }
+
+        /// <summary>
+        ///     Queueing startup requests to the queue.
+        /// </summary>
         public void Request(AirStickerProjector projector, Action onLaunch)
         {
             _launchRequestQueues.Enqueue(new LaunchRequest(projector, onLaunch));
@@ -39,7 +53,7 @@ namespace AirSticker.Runtime.Scripts.Core
 
         private bool IsCurrentRequestFinished()
         {
-            if (_currentRequest == null) return true; // The request is empty.
+            if (!_hasCurrentRequest) return true; // The request is empty.
 
             var projector = _currentRequest.Projector;
             // Even if the projector is dead or the launching is canceled, its scheduled jobs may still be
@@ -58,10 +72,13 @@ namespace AirSticker.Runtime.Scripts.Core
         {
             while (_launchRequestQueues.Count > 0)
             {
-                _currentRequest = _launchRequestQueues.Peek();
-                _launchRequestQueues.Dequeue();
+                _currentRequest = _launchRequestQueues.Dequeue();
+                _hasCurrentRequest = true;
                 if (!_currentRequest.Projector) continue; // This request was dead, so skipped.
-                _currentRequest.OnLaunch();
+                if (_currentRequest.OnLaunch != null)
+                    _currentRequest.OnLaunch();
+                else
+                    _currentRequest.Projector.OnLaunchRequestAccepted();
                 break;
             }
         }
@@ -71,7 +88,9 @@ namespace AirSticker.Runtime.Scripts.Core
             return _launchRequestQueues.Count;
         }
 
-        private class LaunchRequest
+        // A struct so that queueing a request does not allocate. OnLaunch is null for the projector's own
+        // launch path, which calls AirStickerProjector.OnLaunchRequestAccepted instead of a delegate.
+        private readonly struct LaunchRequest
         {
             public LaunchRequest(AirStickerProjector projector, Action onLaunch)
             {

--- a/Assets/AirSticker/Runtime/Scripts/Core/TrianglePolygonsFactory.cs
+++ b/Assets/AirSticker/Runtime/Scripts/Core/TrianglePolygonsFactory.cs
@@ -28,6 +28,10 @@ namespace AirSticker.Runtime.Scripts.Core
         private NativeArray<Vector3> _workingVertexPositions =
             new NativeArray<Vector3>(MaxWorkingVertexCount, Allocator.Persistent);
 
+        // Reused across launches. It is created on the first skinned receiver instead of in the constructor,
+        // because its capacity is worth ~2 MB and projects without skinned receivers never need it.
+        private List<BoneWeight> _workingBoneWeights;
+
         private bool _disposed;
         private static int _maxGeneratedPolygonPerFrame = 100000;
 
@@ -59,9 +63,9 @@ namespace AirSticker.Runtime.Scripts.Core
         ///     resultHolder[0]; it is left null if a mesh is not Read/Write enabled (nothing to build).
         /// </summary>
         internal IEnumerator BuildFromReceiverObject(
-            MeshRenderer[] meshRenderers,
-            SkinnedMeshRenderer[] skinnedMeshRenderers,
-            Terrain[] terrains,
+            IReadOnlyList<MeshRenderer> meshRenderers,
+            IReadOnlyList<SkinnedMeshRenderer> skinnedMeshRenderers,
+            IReadOnlyList<Terrain> terrains,
             ReceiverConvexPolygonsMesh[] resultHolder)
         {
             var numTerrainMeshPolygon = GetNumPolygonsFromTerrains(terrains, 1.0f);
@@ -81,7 +85,7 @@ namespace AirSticker.Runtime.Scripts.Core
             if (!buildSkin) skinTriangleCount = 0;
 
             var triangleCount = meshTriangleCount + skinTriangleCount + terrainTriangleCount;
-            var componentCount = meshRenderers.Length + skinnedMeshRenderers.Length + terrains.Length;
+            var componentCount = meshRenderers.Count + skinnedMeshRenderers.Count + terrains.Count;
 
             var result = new ReceiverConvexPolygonsMesh(triangleCount, componentCount, Allocator.Persistent);
             // Expose the freshly allocated result to the caller immediately so its OnDestroy can dispose it if
@@ -91,16 +95,16 @@ namespace AirSticker.Runtime.Scripts.Core
 
             // Unify the receiver components into one global index space: mesh renderers, then skinned mesh
             // renderers, then terrains.
-            var skinnedBase = meshRenderers.Length;
-            var terrainBase = meshRenderers.Length + skinnedMeshRenderers.Length;
-            for (var i = 0; i < meshRenderers.Length; i++) result.ComponentByIndex[i] = meshRenderers[i];
-            for (var j = 0; j < skinnedMeshRenderers.Length; j++)
+            var skinnedBase = meshRenderers.Count;
+            var terrainBase = meshRenderers.Count + skinnedMeshRenderers.Count;
+            for (var i = 0; i < meshRenderers.Count; i++) result.ComponentByIndex[i] = meshRenderers[i];
+            for (var j = 0; j < skinnedMeshRenderers.Count; j++)
             {
                 result.ComponentByIndex[skinnedBase + j] = skinnedMeshRenderers[j];
                 result.ComponentIsSkinned[skinnedBase + j] = true;
             }
 
-            for (var k = 0; k < terrains.Length; k++) result.ComponentByIndex[terrainBase + k] = terrains[k];
+            for (var k = 0; k < terrains.Count; k++) result.ComponentByIndex[terrainBase + k] = terrains[k];
 
             _writeTriangleCursor = 0;
             if (buildMesh) yield return FillFromMeshRenderers(meshRenderers, result);
@@ -124,10 +128,11 @@ namespace AirSticker.Runtime.Scripts.Core
         // matches the mesh-renderer region of ComponentByIndex, even when a child has a MeshFilter without a
         // MeshRenderer or vice versa. The polygon count (GetNumPolygonsFromMeshRenderers) is driven the same
         // way, so the total stays consistent with BuildFromReceiverObject's completeness check.
-        private IEnumerator FillFromMeshRenderers(MeshRenderer[] meshRenderers, ReceiverConvexPolygonsMesh result)
+        private IEnumerator FillFromMeshRenderers(
+            IReadOnlyList<MeshRenderer> meshRenderers, ReceiverConvexPolygonsMesh result)
         {
             var polygonNoInFill = 0;
-            for (var rendererNo = 0; rendererNo < meshRenderers.Length; rendererNo++)
+            for (var rendererNo = 0; rendererNo < meshRenderers.Count; rendererNo++)
             {
                 var meshRenderer = meshRenderers[rendererNo];
                 if (!meshRenderer) continue;
@@ -168,11 +173,12 @@ namespace AirSticker.Runtime.Scripts.Core
         }
 
         private IEnumerator FillFromSkinnedMeshRenderers(
-            SkinnedMeshRenderer[] skinnedMeshRenderers, int componentBase, ReceiverConvexPolygonsMesh result)
+            IReadOnlyList<SkinnedMeshRenderer> skinnedMeshRenderers, int componentBase,
+            ReceiverConvexPolygonsMesh result)
         {
-            var workingBoneWeights = new List<BoneWeight>(MaxWorkingVertexCount);
+            var workingBoneWeights = _workingBoneWeights ??= new List<BoneWeight>(MaxWorkingVertexCount);
             var polygonNoInFill = 0;
-            for (var rendererNo = 0; rendererNo < skinnedMeshRenderers.Length; rendererNo++)
+            for (var rendererNo = 0; rendererNo < skinnedMeshRenderers.Count; rendererNo++)
             {
                 var skinnedMeshRenderer = skinnedMeshRenderers[rendererNo];
                 if (!skinnedMeshRenderer || skinnedMeshRenderer.sharedMesh == null) yield break;
@@ -216,9 +222,10 @@ namespace AirSticker.Runtime.Scripts.Core
         }
 
         private IEnumerator FillFromTerrains(
-            Terrain[] terrains, int componentBase, float terrainMeshResolutionScale, ReceiverConvexPolygonsMesh result)
+            IReadOnlyList<Terrain> terrains, int componentBase, float terrainMeshResolutionScale,
+            ReceiverConvexPolygonsMesh result)
         {
-            for (var terrainNo = 0; terrainNo < terrains.Length; terrainNo++)
+            for (var terrainNo = 0; terrainNo < terrains.Count; terrainNo++)
             {
                 var terrain = terrains[terrainNo];
                 if (!terrain || terrain == null) yield break;
@@ -290,11 +297,12 @@ namespace AirSticker.Runtime.Scripts.Core
             _writeTriangleCursor++;
         }
 
-        private static int GetNumPolygonsFromSkinModelRenderers(SkinnedMeshRenderer[] skinnedMeshRenderers)
+        private static int GetNumPolygonsFromSkinModelRenderers(IReadOnlyList<SkinnedMeshRenderer> skinnedMeshRenderers)
         {
             var numPolygon = 0;
-            foreach (var renderer in skinnedMeshRenderers)
+            for (var rendererNo = 0; rendererNo < skinnedMeshRenderers.Count; rendererNo++)
             {
+                var renderer = skinnedMeshRenderers[rendererNo];
                 if (!renderer || renderer.sharedMesh == null) return -1;
                 var mesh = renderer.sharedMesh;
                 if (mesh.isReadable == false)
@@ -304,8 +312,21 @@ namespace AirSticker.Runtime.Scripts.Core
                     return -1;
                 }
 
-                numPolygon += mesh.triangles.Length / 3;
+                numPolygon += GetNumPolygonsFromMesh(mesh);
             }
+
+            return numPolygon;
+        }
+
+        // Counted from the index counts instead of mesh.triangles, which copies the whole index buffer into a
+        // managed array just to be measured (360 KB of garbage for a 30k-polygon model). The per-submesh
+        // division matches how the Fill* methods walk the submeshes, so the count and the fill always agree.
+        private static int GetNumPolygonsFromMesh(Mesh mesh)
+        {
+            var numPolygon = 0;
+            var subMeshCount = mesh.subMeshCount;
+            for (var meshNo = 0; meshNo < subMeshCount; meshNo++)
+                numPolygon += (int)(mesh.GetIndexCount(meshNo) / 3);
 
             return numPolygon;
         }
@@ -318,20 +339,23 @@ namespace AirSticker.Runtime.Scripts.Core
             return (vertexCountX - 1) * (vertexCountY - 1) * 2;
         }
 
-        private static int GetNumPolygonsFromTerrains(Terrain[] terrains, float terrainMeshResolutionScale)
+        private static int GetNumPolygonsFromTerrains(
+            IReadOnlyList<Terrain> terrains, float terrainMeshResolutionScale)
         {
             var numPolygon = 0;
-            foreach (var terrain in terrains) numPolygon += GetNumPolygonsFromTerrain(terrain, terrainMeshResolutionScale);
+            for (var terrainNo = 0; terrainNo < terrains.Count; terrainNo++)
+                numPolygon += GetNumPolygonsFromTerrain(terrains[terrainNo], terrainMeshResolutionScale);
             return numPolygon;
         }
 
         // Renderer-driven so it stays consistent with FillFromMeshRenderers: a renderer without a MeshFilter
         // (or without a mesh) contributes nothing, and only a non-readable mesh aborts the whole mesh path.
-        private static int GetNumPolygonsFromMeshRenderers(MeshRenderer[] meshRenderers)
+        private static int GetNumPolygonsFromMeshRenderers(IReadOnlyList<MeshRenderer> meshRenderers)
         {
             var numPolygon = 0;
-            foreach (var meshRenderer in meshRenderers)
+            for (var rendererNo = 0; rendererNo < meshRenderers.Count; rendererNo++)
             {
+                var meshRenderer = meshRenderers[rendererNo];
                 if (!meshRenderer) continue;
                 var meshFilter = meshRenderer.GetComponent<MeshFilter>();
                 if (!meshFilter || meshFilter.sharedMesh == null) continue;
@@ -343,7 +367,7 @@ namespace AirSticker.Runtime.Scripts.Core
                     return -1;
                 }
 
-                numPolygon += mesh.triangles.Length / 3;
+                numPolygon += GetNumPolygonsFromMesh(mesh);
             }
 
             return numPolygon;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ All runtime code is in `Assets/AirSticker/Runtime/Scripts` (single asmdef `AirSt
 3. Hands off to a **ThreadPool worker thread**: skinning matrices applied, broad-phase cull (`BroadPhaseConvexPolygonsDetection` — face-normal + distance rejection), six clip planes built from the decal box (width/height/depth in decal space), convex polygons split against them (`ConvexPolygon.SplitAndRemoveByPlane`), and resulting triangle fans appended to the decal meshes. The coroutine polls a flag until the worker finishes.
 4. Back on the main thread, `DecalMesh.ExecutePostProcessingAfterWorkerThread()` uploads the results to Unity `Mesh` objects.
 
-`DecalMesh` spawns a child GameObject named **`"AirStickerRenderer"`** under the receiver (`DecalMeshRenderer`), with a `MeshRenderer` or `SkinnedMeshRenderer` (bones copied from the receiver) matching the source. That literal name is load-bearing: `ExecuteLaunch()` filters out skinned renderers named `AirStickerRenderer` when gathering receiver geometry.
+`DecalMesh` spawns a child GameObject named **`"AirStickerRenderer"`** under the receiver (`DecalMeshRenderer`), with a `MeshRenderer` or `SkinnedMeshRenderer` (bones copied from the receiver) matching the source. It also carries an internal `DecalMeshRendererMarker` component, which is how `ExecuteLaunch()` filters those renderers out when gathering receiver geometry (the name itself is only for hierarchy readability — `Renderer.name` allocates, so it is not used for the check). `Assets/Demo/Demo_Benchmark` still matches on the literal name, so keep the name stable.
 
 ### Constraints to keep in mind
 


### PR DESCRIPTION
## 概要

decal を1枚貼るときの **launch 開始フレームに出ていた 5.1KB の GC.Alloc** を削除しました。PR #39 で消したのは毎フレーム分で、本PRは **1 launch あたり**に残っていた分です。

計画上の Phase 2 に相当します。低リスク・機械的な項目だけをまとめたので、この後に入れる `DecalMesh` の NativeArray 化（145.8KB フレーム）のプロファイル差分が読みやすくなります。

## 内訳と対処

| 実体 | 対処 |
| --- | --- |
| `CalculateHash` の文字列補間 | `HashCode.Combine` に置換 |
| `.Where(s => s.name != "AirStickerRenderer").ToArray()` | 内部マーカーコンポーネント + `TryGetComponent` 判定に変更 |
| `GetComponentsInChildren<T>()` ×5 の戻り値配列 | `(bool, List<T>)` オーバーロード + 使い回しリスト |
| receiver ごとの `new List<DecalMesh>()` | フィールド化して `Clear()` 再利用 |
| `mesh.triangles.Length / 3` | `GetIndexCount(submesh)` の合計に置換 |
| `new List<BoneWeight>(65536)`（約2MB） | フィールド化（初回スキン receiver で遅延生成） |
| `LaunchRequest` + `Action` クロージャ | `readonly struct` 化 + メソッド直呼び |

## 変更内容

### `CalculateHash` の文字列補間

receiver 配下のレンダラー数ぶん string を確保していたので `HashCode.Combine` に置き換えました。戻り値は変わりますが、プール内の `Dictionary` キーとしてしか使っておらず永続化していないので影響はありません。衝突耐性も上がります。

### `AirStickerRenderer` 判定

`Renderer.name` はゲッター呼び出しごとに string を確保するため、LINQ イテレータと配列に加えてレンダラー数ぶんの無駄が出ていました。`DecalMeshRenderer` が生成時に付与する内部マーカーコンポーネント `DecalMeshRendererMarker` の `TryGetComponent` 判定に置き換えています。

**GameObject 名 `"AirStickerRenderer"` は据え置き**です（ヒエラルキーの可読性と `Demo_Benchmark` が参照しているため）。判定手段だけ差し替えました。除外は `List` のインプレース圧縮 + `RemoveRange` なので、フィルタ自体もアロケーションしません。

### `GetComponentsInChildren` ×5

5箇所すべて `(bool, List<T>)` オーバーロードに置き換え、リストを使い回しています。`includeInactive: false` は配列版のデフォルトと同じなので挙動は変わりません。

- **projector 側の3本**（mesh / skinned / terrain）はフレーム分割抽出をまたいで保持されるため、system 共有ではなく projector のインスタンスフィールドにしています。
- **`CollectEditDecalMeshes` 用の2本**は同じ呼び出し内で使い切るので system 側に別枠で持たせています。

あわせて `BuildFromReceiverObject` 系の引数を `IReadOnlyList<T>` にしました。インターフェース経由の `foreach` は `Enumerator` が boxing されるため、内部の列挙はすべて index ループにしてあります。

### ポリゴン数カウント

`mesh.triangles.Length / 3` は、数を数えるためだけにインデックスバッファ全体を managed 配列にコピーしていました。デモは低ポリなので目立ちませんが、**3万ポリゴンのモデルなら1回で 360KB** 確保する計算です。`GetIndexCount(submesh)` の合計に置き換えました。

サブメッシュ単位で3で割る形にしたので、fill 側のループ（`mesh.GetIndexCount(meshNo) / 3`）と数え方が完全に一致します。副次的に、非三角形トポロジが混ざったときにカウントと fill がずれて `_writeTriangleCursor != triangleCount` で source 全体が破棄される可能性も消えました。

### `List<BoneWeight>`

`65536 × 32B ≒ 2MB` を呼ばれるたびに確保していたのでフィールドに移しました。ただし常駐させるには大きいので、**初回のスキン receiver で遅延生成**し、スキンモデルを使わないプロジェクトでは確保しないようにしています。

### `LaunchRequest`

`readonly struct` 化し、launcher に `Action` 不要の `Request(projector)` を追加して projector の `OnLaunchRequestAccepted()` を直呼びする形にしました。既存の public な `Request(projector, Action)` は互換のため残しています。

### そのほか

使い回しリストが破棄済み receiver のレンダラー参照を次の launch まで抱えないよう、`OnFinished()` でリストを `Clear()` しています。

判定・状態遷移・生成されるジオメトリは変更しておらず、挙動は同一です。

## 確認したこと

- `AirSticker.csproj` / `Tests.csproj` / `Assembly-CSharp.csproj` を MSBuild でビルドし、エラー・新規警告なし。
- エディタ上でデモシーンの動作確認済み。
- EditMode テスト 4 本（`TestConvexPolygonClipping` / `TestDecalMeshTangents` / `TestDecalMeshPool` / `TestCreateAndLaunch`）を Test Runner で実行し、全件パス。

## 残課題（本PRの対象外）

計画上の Phase 1 / Phase 3 として別PRで対応します。

- **`DecalMesh.AppendFromJobOutput` の `Array.Resize` ×6（145.8KB）** — 全体の約96%。同じ `DecalMesh` に貼り重ねるほど O(n²) のゴミになるので、`NativeArray` + 容量2倍成長への置換が本命。
- **`DecalMeshRenderer` の毎 launch 再生成** — Mesh 自体は使い回しているので、既存インスタンスがあれば何もしない形にできる。
- **`ScheduleClipStage` の `smr.bones` / `bindposes`** — receiver ごとに不変なので、抽出時に一度だけ持たせられる。

以下は本PRでは手を付けていない既存の挙動です（挙動変更を含むため分離しました）。

- `_meshRenderers` 側にはマーカーフィルタを入れていません。現行コードも静的 decal renderer を receiver として拾い得ますが、2枚目以降は三角形プールがヒットして抽出自体が走らないため実際にはほぼ到達しません。
- `CollectEditDecalMeshes` の `if (!renderer) return;` は `EnableDecalMeshRenderers()` を呼ばずに抜けるため、decal renderer が非表示のまま残ります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


