### PR TITLE
DecalMeshのCPUバッファをNativeArray化してArray.Resizeを削除

### DIFF
--- a/Assets/AirSticker/Runtime/Scripts/Core/DecalMesh.cs
+++ b/Assets/AirSticker/Runtime/Scripts/Core/DecalMesh.cs
@@ -43,18 +43,28 @@ namespace AirSticker.Runtime.Scripts.Core
         private readonly Material _decalMaterial;
         private readonly Component _receiverComponent;
         private readonly GameObject _receiverObject;
-        private BoneWeight[] _boneWeightsBuffer;
         private DecalMeshRenderer _decalMeshRenderer;
         private bool _disposed;
-
-        private int[] _indexBuffer;
         private Mesh _mesh;
-        private Vector3[] _normalBuffer;
+
+        // The CPU-side geometry, accumulated across every launch that projects onto this mesh.
+        // They are NativeArrays with doubling capacity rather than managed arrays sized exactly to
+        // _numVertex / _numIndex: Array.Resize allocates a new array of the exact length on every append, so
+        // pasting a second decal onto the same mesh copied the first decal's vertices into fresh garbage, and
+        // the garbage grew quadratically with the number of decals. Native memory is not counted as GC.Alloc,
+        // and doubling makes the reallocations amortized-constant.
+        // Only the main thread touches them (append and upload run after the jobs have completed), so no job
+        // dependency has to be tracked; Dispose is the only owner (see the remarks on Dispose).
+        private NativeArray<float3> _positionBuffer;
+        private NativeArray<float3> _normalBuffer;
+        private NativeArray<float2> _uvBuffer;
+        private NativeArray<float4> _tangentBuffer;
+        private NativeArray<BoneWeight> _boneWeightsBuffer;
+        private NativeArray<int> _indexBuffer;
+
+        // The logical lengths of the buffers above. They are independent of the buffers' capacity.
         private int _numIndex;
         private int _numVertex;
-        private Vector3[] _positionBuffer;
-        private Vector4[] _tangentBuffer;
-        private Vector2[] _uvBuffer;
 
         public DecalMesh(
             GameObject receiverObject,
@@ -81,12 +91,28 @@ namespace AirSticker.Runtime.Scripts.Core
         internal Material DecalMaterial => _decalMaterial;
         internal Component ReceiverComponent => _receiverComponent;
 
+        /// <summary>
+        ///     Destroy the mesh and free the CPU-side buffers.
+        /// </summary>
+        /// <remarks>
+        ///     There is deliberately no finalizer to fall back on. Object.Destroy and NativeArray.Dispose are
+        ///     both unsafe on the finalizer thread (the implementation before the buffers became NativeArrays
+        ///     called Dispose from one), so a finalizer could not release anything here. Every DecalMesh is
+        ///     owned by DecalMeshPool, which disposes it from GarbageCollect / RemoveDecalMeshes / Dispose, so
+        ///     a missed Dispose means the pool was bypassed; the editor's Native Collection leak detection
+        ///     reports the buffers in that case.
+        /// </remarks>
         public void Dispose()
         {
             if (_disposed) return;
-            if (_mesh && _mesh != null) Object.Destroy(_mesh);
-            GC.SuppressFinalize(this);
             _disposed = true;
+            if (_mesh && _mesh != null) Object.Destroy(_mesh);
+            DisposeIfCreated(ref _positionBuffer);
+            DisposeIfCreated(ref _normalBuffer);
+            DisposeIfCreated(ref _uvBuffer);
+            DisposeIfCreated(ref _tangentBuffer);
+            DisposeIfCreated(ref _boneWeightsBuffer);
+            DisposeIfCreated(ref _indexBuffer);
         }
 
         /// <summary>
@@ -172,7 +198,8 @@ namespace AirSticker.Runtime.Scripts.Core
             }
             else
             {
-                meshData.GetIndexData<int>().CopyFrom(_indexBuffer);
+                // Copied by range instead of CopyFrom, because the buffer's capacity is larger than _numIndex.
+                NativeArray<int>.Copy(_indexBuffer, 0, meshData.GetIndexData<int>(), 0, _numIndex);
             }
 
             meshData.subMeshCount = 1;
@@ -194,11 +221,6 @@ namespace AirSticker.Runtime.Scripts.Core
                 _mesh);
         }
 
-        ~DecalMesh()
-        {
-            Dispose();
-        }
-
         /// <summary>
         ///     Check to can the decal mesh remove from the pool.
         ///     If this function return true, it will be removed from the pool.
@@ -217,6 +239,8 @@ namespace AirSticker.Runtime.Scripts.Core
         public void Clear()
         {
             _decalMeshRenderer?.Destroy();
+            // The logical lengths are reset but the buffers keep their capacity, so re-pasting onto this mesh
+            // does not have to grow them again.
             _numIndex = 0;
             _numVertex = 0;
             Object.Destroy(_mesh);
@@ -271,24 +295,55 @@ namespace AirSticker.Runtime.Scripts.Core
             var addIndexNo = _numIndex;
 
             _numVertex += vertexCount;
-            Array.Resize(ref _positionBuffer, _numVertex);
-            Array.Resize(ref _normalBuffer, _numVertex);
-            Array.Resize(ref _boneWeightsBuffer, _numVertex);
-            Array.Resize(ref _uvBuffer, _numVertex);
-            Array.Resize(ref _tangentBuffer, _numVertex);
-            for (var k = 0; k < vertexCount; k++)
-            {
-                _positionBuffer[addVertNo + k] = positions[vertexOffset + k];
-                _normalBuffer[addVertNo + k] = normals[vertexOffset + k];
-                _uvBuffer[addVertNo + k] = uvs[vertexOffset + k];
-                _tangentBuffer[addVertNo + k] = tangents[vertexOffset + k];
-                _boneWeightsBuffer[addVertNo + k] = boneWeights[vertexOffset + k];
-            }
+            EnsureCapacity(ref _positionBuffer, _numVertex, addVertNo);
+            EnsureCapacity(ref _normalBuffer, _numVertex, addVertNo);
+            EnsureCapacity(ref _uvBuffer, _numVertex, addVertNo);
+            EnsureCapacity(ref _tangentBuffer, _numVertex, addVertNo);
+            EnsureCapacity(ref _boneWeightsBuffer, _numVertex, addVertNo);
+            NativeArray<float3>.Copy(positions, vertexOffset, _positionBuffer, addVertNo, vertexCount);
+            NativeArray<float3>.Copy(normals, vertexOffset, _normalBuffer, addVertNo, vertexCount);
+            NativeArray<float2>.Copy(uvs, vertexOffset, _uvBuffer, addVertNo, vertexCount);
+            NativeArray<float4>.Copy(tangents, vertexOffset, _tangentBuffer, addVertNo, vertexCount);
+            NativeArray<BoneWeight>.Copy(boneWeights, vertexOffset, _boneWeightsBuffer, addVertNo, vertexCount);
 
             _numIndex += indexCount;
-            Array.Resize(ref _indexBuffer, _numIndex);
+            EnsureCapacity(ref _indexBuffer, _numIndex, addIndexNo);
+            // Not a bulk copy, because every index has to be shifted into this mesh's vertex space.
             for (var k = 0; k < indexCount; k++)
                 _indexBuffer[addIndexNo + k] = indices[indexOffset + k] + indexDelta;
+        }
+
+        /// <summary>
+        ///     Make sure the buffer can hold <paramref name="requiredLength" /> elements, preserving the first
+        ///     <paramref name="copyLength" /> of them.
+        /// </summary>
+        /// <remarks>
+        ///     The capacity is doubled rather than grown to exactly the required length, so that appending to a
+        ///     mesh that already holds decals stays amortized-constant instead of copying the whole buffer on
+        ///     every append.
+        /// </remarks>
+        private static void EnsureCapacity<T>(ref NativeArray<T> buffer, int requiredLength, int copyLength)
+            where T : struct
+        {
+            if (buffer.IsCreated && buffer.Length >= requiredLength) return;
+
+            var newLength = buffer.IsCreated
+                ? math.max(requiredLength, buffer.Length * 2)
+                : math.max(requiredLength, 1);
+            var newBuffer = new NativeArray<T>(newLength, Allocator.Persistent,
+                NativeArrayOptions.UninitializedMemory);
+            if (buffer.IsCreated)
+            {
+                if (copyLength > 0) NativeArray<T>.Copy(buffer, 0, newBuffer, 0, copyLength);
+                buffer.Dispose();
+            }
+
+            buffer = newBuffer;
+        }
+
+        private static void DisposeIfCreated<T>(ref NativeArray<T> buffer) where T : struct
+        {
+            if (buffer.IsCreated) buffer.Dispose();
         }
 
         [StructLayout(LayoutKind.Sequential)]


### PR DESCRIPTION
## 概要

decal を1枚貼るときの**仕上げフレームに出ていた 145.8KB の GC.Alloc** を削除しました。PR #39（毎フレーム分）・PR #40（launch 開始フレームの 5.1KB）に続くもので、計測で見えていた4フレームのうち**全体の約96%を占めていた最大の山**です。

計画上の Phase 1 のうち **1-a のみ**を対象としています。1-b / 1-c は実機で描画不具合を踏んだため見送りました（詳細は末尾）。

## 原因

`DecalMesh.AppendFromJobOutput()` が position / normal / uv / tangent / boneWeight / index の6本のマネージド配列を毎 launch `Array.Resize` していました。

`Array.Resize` は**必要長ぴったりの配列を新規確保してコピー**するため、同じ `DecalMesh` に貼り重ねるほどゴミが二次オーダーで増えます。2枚目の decal は1枚目の頂点まで新しい配列にコピーし直し、古い配列を丸ごとゴミにしていました。1頂点あたり managed 80B + インデックス分です。

## 変更内容

### CPU バッファの NativeArray 化

6本を `NativeArray<T>`（`Allocator.Persistent`）+ **容量2倍成長**に置き換え、論理長（`_numVertex` / `_numIndex`）と容量を分離しました。

- ネイティブメモリは GC.Alloc に計上されないため、**このフレームの GC.Alloc がゼロになります**
- 容量2倍成長により、貼り重ね時の再確保が amortized-constant になり二次オーダーが消えます
- ジョブ出力からのコピーは `NativeArray<T>.Copy` で一括にしました。インデックスだけは各要素をこのメッシュの頂点空間へシフトする必要があるためループのままですが、確保は発生しません

これらのバッファはジョブ完了後のメインスレッドでしか触らないので、ジョブ依存の追跡は不要です。所有者は `Dispose()` だけになります。

### 解放経路の整理

- `Dispose()` で6本すべてを `Dispose` します。`DecalMeshPool` の `GarbageCollect()` / `RemoveDecalMeshes()` / `Dispose()` がいずれも `DecalMesh.Dispose()` を通るので、プール経由の解放は網羅されています。リポジトリ内で `DecalMesh` を生成するのは `AirStickerSystem.CollectEditDecalMeshes()` のプール登録経路のみです。
- **`~DecalMesh()` を削除**し、不要になった `Dispose()` の `GC.SuppressFinalize(this)` も削除しました。ファイナライザは `Dispose()` を呼んでいましたが、`Object.Destroy()` も `NativeArray` の解放もファイナライザスレッドでは安全ではなく、ファイナライザから解放できるものがありません。フォールバックを持たない代わりに、解放漏れはエディタの Native Collection リーク検出に委ねる方針を `Dispose()` の remarks に明記しています。
- UInt32 インデックス経路の `GetIndexData<int>().CopyFrom(_indexBuffer)` は長さ一致が必要なため、容量が論理長より大きくなった今は使えません。`NativeArray<int>.Copy` で `_numIndex` 分だけコピーする形にしました。

生成されるジオメトリとアップロード内容は変更していません。

## 確認したこと

- `AirSticker.csproj` / `Tests.csproj` を MSBuild でビルドし、エラー・新規警告なし。
- EditMode テスト4本（`TestConvexPolygonClipping` / `TestDecalMeshTangents` / `TestDecalMeshPool` / `TestCreateAndLaunch`）を実行し、全件パス。
- エディタ上でデモシーンの動作確認済み（1枚目・2枚目の貼り重ね、スキンモデル含む）。
- Codex CLI によるセルフレビューを3往復実施。指摘3件（いずれもファイナライザ周辺のコメントと Unity API 呼び出し）を反映し、最終的にファイナライザの削除に至りました。

## 見送った項目（計画の Phase 1 のうち 1-b / 1-c）

いずれも実装して実機確認したうえで**撤回**しました。「Unity が既にやっていること」を最適化しようとして描画が壊れたケースです。同じ轍を踏まないよう記録を残します。

| 項目 | 撤回理由 |
| --- | --- |
| `DecalMeshRenderer` を毎 launch 作り直さない | 単体では動くが、下記2件と組み合わせて破綻したため一旦取り下げ |
| `_mesh.bindposes` を初回のみ代入 | **`MeshData` に bind pose のチャネルが無く、`ApplyAndDisposeWritableMeshData` がメッシュの中身を丸ごと差し替えるため Apply のたびに bindposes が失われる。** bind pose を単位行列としてスキニングされ、decal の形は保ったまま位置がボーンのワールド変換ぶん飛ぶ |
| `SkinnedMeshRenderer.localBounds` の明示更新 | **スキンの実行時バウンディングはボーンごとの AABB から変形後を覆うよう Unity が算出する。** メッシュ空間の（decal なので薄く平たい）AABB を代入すると体積を潰してカリングを誤り、2枚目以降が消える。そもそも `DontResetBoneBounds` を渡していないので Apply ごとに再計算され、更新自体が不要だった |
| `RecalculateBounds()` → ジョブ算出 AABB + `DontRecalculateBounds` | 累積 AABB は数学的には全頂点 AABB と一致するのに、実機では画面端でデカールが消えた。**原因未特定のまま撤回。** 効果はメインスレッド時間のみで GC には効かないため再挑戦の優先度は低い |

再挑戦する場合は、スキンモデルで「複数レンダラーにまたがる位置」「2枚目以降」「画面端に寄せる」の3条件を必ず確認してください。単一メッシュ1枚目だけでは上記3件とも再現しません。

## 残課題（本PRの対象外）

- **`ScheduleClipStage` の `smr.bones` / `bindposes`** — `bones` は本数カウントと行列書き込みで2回、`bindposes` も毎 launch 確保している。どちらも receiver ごとに不変なので、抽出時に一度だけ持たせられる
- **ネストしたコルーチンのイテレータ** — `BuildFromReceiverObject` の3つの Fill を1本に畳むと数百 B/launch 減る
- **`CreateAndLaunch` の `Clone()` / `new UnityEvent<State>()`** — projector 自体のプーリングは API 変更を伴うため対象外

🤖 Generated with [Claude Code](https://claude.com/claude-code)
