### PR TITLE
コルーチンをUnityEngine.Awaitableに移行

### DIFF
--- a/Assets/AirSticker/Runtime/Scripts/AirStickerProjector.cs
+++ b/Assets/AirSticker/Runtime/Scripts/AirStickerProjector.cs
@@ -1,5 +1,6 @@
-using System.Collections;
+using System;
 using System.Collections.Generic;
+using System.Threading;
 using AirSticker.Runtime.Scripts.Core;
 using AirSticker.Runtime.Scripts.Core.Jobs;
 using Unity.Jobs;
@@ -59,11 +60,20 @@ namespace AirSticker.Runtime.Scripts
         // The pooled source mesh the current launch's jobs are reading, pinned so the pool does not dispose
         // its NativeArrays while the jobs run.
         private ReceiverConvexPolygonsMesh _currentSource;
-        // Holds a source mesh built by the frame-sliced extraction but not yet registered into the pool.
-        // Destroying the projector mid-extraction stops the coroutine before registration, so OnDestroy
-        // disposes it from here to avoid leaking its Persistent NativeArrays. Only one extraction is in flight
-        // at a time, and the holder is cleared as soon as the source is registered.
+        // Receives a source mesh built by the frame-sliced extraction, before it is registered into the pool.
+        // An async method cannot have an out parameter, so the result is handed over through this reused array
+        // rather than a per-launch one. The extraction owns the mesh until it returns and only publishes a
+        // complete one (see TrianglePolygonsFactory.BuildFromReceiverObjectAsync), so whatever is found here
+        // afterwards belongs to this launch: it is either registered into the pool or disposed below.
+        // Only one extraction is in flight at a time.
         private readonly ReceiverConvexPolygonsMesh[] _pendingSourceHolder = new ReceiverConvexPolygonsMesh[1];
+
+        // True from the moment the launcher starts the launch body until the body has returned. The body is an
+        // async method, so unlike the coroutine it used to be it keeps running after the projector is
+        // destroyed, and it is not finished just because NowState says so. DecalProjectorLauncher waits for
+        // this before starting the next launch, because the extraction and the job pipeline are shared between
+        // launches (see IsExecutingLaunch).
+        private bool _executingLaunch;
 
         // The working lists of ExecuteLaunch, kept as fields so the launch does not allocate a list (or an
         // array from GetComponentsInChildren) per receiver object. The renderer/terrain lists are held across
@@ -79,12 +89,23 @@ namespace AirSticker.Runtime.Scripts
         ///     True while this projector's jobs are scheduled and not yet completed.
         /// </summary>
         /// <remarks>
-        ///     Destroying the projector stops its coroutine but not the scheduled jobs, which write to the
-        ///     pipeline's pooled buffers. Starting the next launch in that state would corrupt those buffers,
-        ///     so DecalProjectorLauncher must wait until the jobs finish. The C# instance is still readable
-        ///     after the Unity object is destroyed. OnDestroy also completes the jobs to release the pool.
+        ///     Destroying the projector does not stop the scheduled jobs, which write to the pipeline's pooled
+        ///     buffers. Starting the next launch in that state would corrupt those buffers, so
+        ///     DecalProjectorLauncher must wait until the jobs finish. The C# instance is still readable after
+        ///     the Unity object is destroyed. OnDestroy also completes the jobs to release the pool.
         /// </remarks>
         internal bool IsWorkerThreadRunning => _jobsScheduled && !_currentJobHandle.IsCompleted;
+
+        /// <summary>
+        ///     True while the launch body has not returned yet, even if the projector was destroyed.
+        /// </summary>
+        /// <remarks>
+        ///     The launch body observes the destruction and unwinds at its next resume point, which is a frame
+        ///     later at the earliest. Until then it must not overlap the next launch: the triangle extraction
+        ///     shares its working buffers and write cursor across launches, as does the job pipeline. The body
+        ///     always clears this, including on cancellation and on an exception, so the launcher cannot stall.
+        /// </remarks>
+        internal bool IsExecutingLaunch => _executingLaunch;
 
         /// <summary>
         ///     State of decal projector.
@@ -103,30 +124,16 @@ namespace AirSticker.Runtime.Scripts
 
         private void OnDestroy()
         {
-            // The coroutine is stopped by the destruction, but the scheduled jobs are not, and they write to
-            // the pipeline's pooled buffers. Complete them here so the next launch can reuse the pool safely.
-            if (_jobsScheduled)
-            {
-                _currentJobHandle.Complete();
-                _jobsScheduled = false;
-            }
+            // The scheduled jobs are not stopped by the destruction, and they write to the pipeline's pooled
+            // buffers. Complete them here so the next launch can reuse the pool safely, and unpin the source
+            // so the pool can dispose it.
+            ReleaseJobResources();
 
-            // Release the pinned source so the pool can dispose it.
-            if (_currentSource != null)
-            {
-                _currentSource.InUse = false;
-                _currentSource = null;
-            }
-
-            // Dispose a source built by the frame-sliced extraction but not yet registered into the pool.
-            // Destroying the projector during extraction stops the coroutine before registration, so this is
-            // the only owner. No jobs read it yet (they are scheduled only after registration), so disposing
-            // here is safe; once registered the holder is cleared, so this never disposes a pooled source.
-            if (_pendingSourceHolder[0] != null)
-            {
-                _pendingSourceHolder[0].Dispose();
-                _pendingSourceHolder[0] = null;
-            }
+            // _pendingSourceHolder is deliberately not touched. The extraction may still be running (it only
+            // notices the destruction at its next resume point) and it owns the mesh it is filling, so
+            // disposing it here would free NativeArrays that are still being written. The extraction disposes
+            // its own result when it observes the cancellation, and the launch body drops anything that was
+            // handed over just before the destruction.
 
             // It may be deleted without completing the projection, so we finish it here too.
             // No geometry rollback is needed: the new pipeline appends to the decal meshes only on the main
@@ -165,15 +172,15 @@ namespace AirSticker.Runtime.Scripts
 
         private void OnFinished(State finishedState)
         {
-            // The launch is over (completed, canceled or destroyed), so the reused working lists must not keep
-            // the receiver's renderers alive until the next launch.
-            ClearWorkingLists();
-
             if (onFinishedLaunch == null) return;
 
-            onFinishedLaunch.Invoke(finishedState);
+            // The state is published before the callback runs, so that a listener throwing cannot leave
+            // NowState at Launching -- DecalProjectorLauncher would then wait for this projector forever.
+            // Listeners get the state as their argument anyway.
             NowState = finishedState;
+            var callback = onFinishedLaunch;
             onFinishedLaunch = null;
+            callback.Invoke(finishedState);
         }
 
         /// <summary>
@@ -183,107 +190,184 @@ namespace AirSticker.Runtime.Scripts
         ///     This process is performed over multiple frames.
         ///     Projection completion can be monitored using callback functions or by checking the NowState property.
         /// </remarks>
-        private IEnumerator ExecuteLaunch()
+        /// <remarks>
+        ///     Nothing awaits the returned Awaitable, so this method must never let an exception escape: it
+        ///     would go unobserved, NowState would stay Launching and the launcher's queue would wait for a
+        ///     state that never comes. Hence the try/catch/finally around the whole body.
+        ///     <br />
+        ///     Every resume point is followed immediately by a cancellation check, because unlike the coroutine
+        ///     this replaces, an async method is not stopped by the projector's destruction: OnDestroy has
+        ///     already completed the jobs and unpinned the source by then, so none of that state may be touched
+        ///     afterwards. Those paths deliberately do not call OnFinished -- OnDestroy did.
+        /// </remarks>
+        private async Awaitable ExecuteLaunchAsync()
         {
-            InitializeOriginAxisInDecalSpace();
-
-            foreach (var receiverObject in receiverObjects)
+            try
             {
-                if (receiverObject == null || !receiverObject) continue;
+                // Cached so the checks below never read the property off an already destroyed MonoBehaviour. The
+                // token is only polled and never handed to Awaitable.NextFrameAsync: a cancelable await
+                // registers a callback on the token's source, which would allocate on every frame this launch
+                // waits. Read inside the try so that nothing at all can throw past the finally below.
+                var cancellation = destroyCancellationToken;
 
-                _receiverDecalMeshes.Clear();
-                AirStickerSystem.CollectEditDecalMeshes(_receiverDecalMeshes, receiverObject, decalMaterial, groupId);
-                DecalMeshes.AddRange(_receiverDecalMeshes);
+                InitializeOriginAxisInDecalSpace();
 
-                receiverObject.GetComponentsInChildren(false, _skinnedMeshRenderers);
-                ExcludeDecalMeshRenderers(_skinnedMeshRenderers);
-                receiverObject.GetComponentsInChildren(false, _terrains);
-
-                if (AirStickerSystem.ReceiverObjectTrianglePolygonsPool.Contains(receiverObject) == false)
+                foreach (var receiverObject in receiverObjects)
                 {
-                    // New receiver object: extract its source triangle polygons (frame-sliced). The result is
-                    // tracked in _pendingSourceHolder so OnDestroy can dispose it if this projector is destroyed
-                    // mid-extraction, before it is registered into the pool below.
-                    _pendingSourceHolder[0] = null;
-                    receiverObject.GetComponentsInChildren(false, _meshRenderers);
-                    yield return AirStickerSystem.BuildTrianglePolygonsFromReceiverObject(
-                        _meshRenderers,
-                        _skinnedMeshRenderers,
-                        _terrains,
-                        _pendingSourceHolder);
+                    if (receiverObject == null || !receiverObject) continue;
 
-                    if (_pendingSourceHolder[0] == null)
+                    _receiverDecalMeshes.Clear();
+                    AirStickerSystem.CollectEditDecalMeshes(_receiverDecalMeshes, receiverObject, decalMaterial,
+                        groupId);
+                    DecalMeshes.AddRange(_receiverDecalMeshes);
+
+                    receiverObject.GetComponentsInChildren(false, _skinnedMeshRenderers);
+                    ExcludeDecalMeshRenderers(_skinnedMeshRenderers);
+                    receiverObject.GetComponentsInChildren(false, _terrains);
+
+                    if (AirStickerSystem.ReceiverObjectTrianglePolygonsPool.Contains(receiverObject) == false)
                     {
-                        // A receiver mesh is not Read/Write enabled, so there is nothing to build.
-                        OnFinished(State.LaunchingCanceled);
-                        yield break;
+                        // New receiver object: extract its source triangle polygons (frame-sliced). The
+                        // extraction owns the result until it returns and hands over only a complete one.
+                        receiverObject.GetComponentsInChildren(false, _meshRenderers);
+                        await AirStickerSystem.BuildTrianglePolygonsFromReceiverObjectAsync(
+                            _meshRenderers,
+                            _skinnedMeshRenderers,
+                            _terrains,
+                            _pendingSourceHolder,
+                            cancellation);
+
+                        if (cancellation.IsCancellationRequested)
+                        {
+                            // The extraction disposes its result when it observes the cancellation, but it may
+                            // also have completed just before the destruction, so drop whatever it handed over.
+                            DisposePendingSource();
+                            return;
+                        }
+
+                        if (_pendingSourceHolder[0] == null)
+                        {
+                            // A receiver mesh is not Read/Write enabled, so there is nothing to build.
+                            OnFinished(State.LaunchingCanceled);
+                            return;
+                        }
+
+                        // The pool takes ownership of the source; stop tracking it here so it is never disposed
+                        // as a pending one while it is pooled (and possibly pinned by a later launch).
+                        AirStickerSystem.ReceiverObjectTrianglePolygonsPool.RegisterTrianglePolygons(
+                            receiverObject, _pendingSourceHolder[0]);
+                        _pendingSourceHolder[0] = null;
                     }
 
-                    // The pool takes ownership of the source; stop tracking it here so OnDestroy never disposes
-                    // a mesh that is pooled (and may be pinned/in use by a later launch).
-                    AirStickerSystem.ReceiverObjectTrianglePolygonsPool.RegisterTrianglePolygons(
-                        receiverObject, _pendingSourceHolder[0]);
-                    _pendingSourceHolder[0] = null;
-                }
+                    if (!receiverObject)
+                    {
+                        OnFinished(State.LaunchingCanceled);
+                        return;
+                    }
 
-                if (!receiverObject)
-                {
-                    OnFinished(State.LaunchingCanceled);
-                    yield break;
-                }
+                    var source = AirStickerSystem.GetTrianglePolygonsFromPool(receiverObject);
+                    if (source == null)
+                    {
+                        OnFinished(State.LaunchingCanceled);
+                        return;
+                    }
 
-                var source = AirStickerSystem.GetTrianglePolygonsFromPool(receiverObject);
-                if (source == null)
-                {
-                    OnFinished(State.LaunchingCanceled);
-                    yield break;
-                }
+                    var pipeline = AirStickerSystem.JobPipeline;
+                    var trans = transform;
+                    // basePosition is the center of the decal box.
+                    var centerPositionOfDecalBox = trans.position + trans.forward * (depth * 0.5f);
 
-                var pipeline = AirStickerSystem.JobPipeline;
-                var trans = transform;
-                // basePosition is the center of the decal box.
-                var centerPositionOfDecalBox = trans.position + trans.forward * (depth * 0.5f);
+                    // Segment 1: skinning + broad phase + clip (parallel jobs).
+                    source.InUse = true;
+                    _currentSource = source;
+                    _currentJobHandle = pipeline.ScheduleClipStage(
+                        source, centerPositionOfDecalBox,
+                        _decalSpace.Ex, _decalSpace.Ey, _decalSpace.Ez,
+                        width, height, depth, projectionBackside);
+                    _jobsScheduled = true;
+                    JobHandle.ScheduleBatchedJobs();
+                    await CompleteJobHandleAsync("clip stage (skinning + broad phase + clip)", cancellation);
+                    if (cancellation.IsCancellationRequested) return;
 
-                // Segment 1: skinning + broad phase + clip (parallel jobs).
-                source.InUse = true;
-                _currentSource = source;
-                _currentJobHandle = pipeline.ScheduleClipStage(
-                    source, centerPositionOfDecalBox,
-                    _decalSpace.Ex, _decalSpace.Ey, _decalSpace.Ez,
-                    width, height, depth, projectionBackside);
-                _jobsScheduled = true;
-                JobHandle.ScheduleBatchedJobs();
-                yield return CompleteJobHandle("clip stage (skinning + broad phase + clip)");
+                    if (!receiverObject)
+                    {
+                        ReleaseJobResources();
+                        OnFinished(State.LaunchingCanceled);
+                        return;
+                    }
 
-                if (!receiverObject)
-                {
+                    // Main-thread step between the segments: size the output from the clip result.
+                    pipeline.CountBuild(source, _receiverDecalMeshes);
+
+                    // Segment 2: build the appended geometry (serial job, off the main thread).
+                    _currentJobHandle = pipeline.ScheduleBuildStage(
+                        source, centerPositionOfDecalBox, _decalSpace.Ex, _decalSpace.Ey,
+                        width, height, zOffsetInDecalSpace);
+                    JobHandle.ScheduleBatchedJobs();
+                    await CompleteJobHandleAsync("build stage (fan + uv + tangent)", cancellation);
+                    if (cancellation.IsCancellationRequested) return;
+
                     _jobsScheduled = false;
                     source.InUse = false;
                     _currentSource = null;
-                    OnFinished(State.LaunchingCanceled);
-                    yield break;
+
+                    // Merge the built geometry into the decal meshes and upload them (main thread).
+                    pipeline.ApplyToDecalMeshes(_receiverDecalMeshes);
+                    foreach (var decalMesh in _receiverDecalMeshes)
+                        decalMesh.ExecutePostProcessingAfterWorkerThread();
                 }
 
-                // Main-thread step between the segments: size the output from the clip result.
-                pipeline.CountBuild(source, _receiverDecalMeshes);
+                OnFinished(State.LaunchingCompleted);
+            }
+            catch (Exception e)
+            {
+                // Ordered so the least fragile work happens first: a throw from here on would escape into the
+                // unobserved Awaitable and leave the launcher waiting. Releasing what this launch owns keeps a
+                // failure from pinning the source (the pool could never dispose it) or leaving jobs
+                // uncompleted, and the log takes no context object so it cannot touch a destroyed projector.
+                ReleaseJobResources();
+                DisposePendingSource();
+                Debug.LogException(e);
+                OnFinished(State.LaunchingCanceled);
+            }
+            finally
+            {
+                _executingLaunch = false;
+                // Released here rather than in OnFinished: OnDestroy calls that while the extraction may still
+                // be iterating these very lists, and it unwinds only at its next resume point.
+                ClearWorkingLists();
+            }
+        }
 
-                // Segment 2: build the appended geometry (serial job, off the main thread).
-                _currentJobHandle = pipeline.ScheduleBuildStage(
-                    source, centerPositionOfDecalBox, _decalSpace.Ex, _decalSpace.Ey,
-                    width, height, zOffsetInDecalSpace);
-                JobHandle.ScheduleBatchedJobs();
-                yield return CompleteJobHandle("build stage (fan + uv + tangent)");
+        /// <summary>
+        ///     Complete the scheduled jobs and unpin the source mesh this launch was reading.
+        /// </summary>
+        private void ReleaseJobResources()
+        {
+            if (_jobsScheduled)
+            {
+                _currentJobHandle.Complete();
                 _jobsScheduled = false;
-                source.InUse = false;
-                _currentSource = null;
-
-                // Merge the built geometry into the decal meshes and upload them (main thread).
-                pipeline.ApplyToDecalMeshes(_receiverDecalMeshes);
-                foreach (var decalMesh in _receiverDecalMeshes) decalMesh.ExecutePostProcessingAfterWorkerThread();
             }
 
-            OnFinished(State.LaunchingCompleted);
-            yield return null;
+            if (_currentSource != null)
+            {
+                _currentSource.InUse = false;
+                _currentSource = null;
+            }
+        }
+
+        /// <summary>
+        ///     Dispose a source mesh that the extraction handed over but that was never registered into the
+        ///     pool, so its Persistent NativeArrays are not leaked. No job reads it yet, because jobs are
+        ///     scheduled only after registration.
+        /// </summary>
+        private void DisposePendingSource()
+        {
+            if (_pendingSourceHolder[0] == null) return;
+
+            _pendingSourceHolder[0].Dispose();
+            _pendingSourceHolder[0] = null;
         }
 
         /// <summary>
@@ -321,7 +405,7 @@ namespace AirSticker.Runtime.Scripts
         ///     synchronously so the actual job compute time is measured; otherwise the main thread polls the
         ///     handle across frames without blocking.
         /// </summary>
-        private IEnumerator CompleteJobHandle(string label)
+        private async Awaitable CompleteJobHandleAsync(string label, CancellationToken cancellation)
         {
             if (AirStickerPerformanceLog.Enabled)
             {
@@ -329,12 +413,18 @@ namespace AirSticker.Runtime.Scripts
                 _currentJobHandle.Complete();
                 sw.Stop();
                 Debug.Log($"[AirSticker][Perf] {label}: {sw.Elapsed.TotalMilliseconds:F2} ms");
+                return;
             }
-            else
+
+            while (!_currentJobHandle.IsCompleted)
             {
-                while (!_currentJobHandle.IsCompleted) yield return null;
-                _currentJobHandle.Complete();
+                await Awaitable.NextFrameAsync();
+                // Destroyed while waiting: OnDestroy has already completed the handle, so leave it alone. The
+                // caller checks the same token and stops.
+                if (cancellation.IsCancellationRequested) return;
             }
+
+            _currentJobHandle.Complete();
         }
 
         /// <summary>
@@ -499,11 +589,18 @@ namespace AirSticker.Runtime.Scripts
         /// </remarks>
         internal void OnLaunchRequestAccepted()
         {
-            if (receiverObjects != null)
-                StartCoroutine(ExecuteLaunch());
-            else
+            if (receiverObjects == null)
+            {
                 // Receiver object has been dead, so process is terminated.
                 OnFinished(State.LaunchingCanceled);
+                return;
+            }
+
+            // Started without being awaited. The body reports through onFinishedLaunch / NowState and handles
+            // its own exceptions, so there is nothing to observe here. It is an Awaitable-returning method
+            // rather than async void so that the state machine comes from Unity's pool.
+            _executingLaunch = true;
+            _ = ExecuteLaunchAsync();
         }
 
         private void InitializeOriginAxisInDecalSpace()

--- a/Assets/AirSticker/Runtime/Scripts/AirStickerSystem.cs
+++ b/Assets/AirSticker/Runtime/Scripts/AirStickerSystem.cs
@@ -1,5 +1,5 @@
-using System.Collections;
 using System.Collections.Generic;
+using System.Threading;
 using AirSticker.Runtime.Scripts.Core;
 using AirSticker.Runtime.Scripts.Core.Jobs;
 using UnityEngine;
@@ -90,17 +90,21 @@ namespace AirSticker.Runtime.Scripts
             Instance = null;
         }
 
-        internal static IEnumerator BuildTrianglePolygonsFromReceiverObject(
+        // Returns the factory's Awaitable directly instead of awaiting it in an async method of its own, so
+        // the call does not build a second state machine per launch.
+        internal static Awaitable BuildTrianglePolygonsFromReceiverObjectAsync(
             IReadOnlyList<MeshRenderer> meshRenderers,
             IReadOnlyList<SkinnedMeshRenderer> skinnedMeshRenderers,
             IReadOnlyList<Terrain> terrains,
-            ReceiverConvexPolygonsMesh[] resultHolder)
+            ReceiverConvexPolygonsMesh[] resultHolder,
+            CancellationToken cancellation)
         {
-            yield return Instance._trianglePolygonsFactory.BuildFromReceiverObject(
+            return Instance._trianglePolygonsFactory.BuildFromReceiverObjectAsync(
                 meshRenderers,
                 skinnedMeshRenderers,
                 terrains,
-                resultHolder);
+                resultHolder,
+                cancellation);
         }
 
         internal static ReceiverConvexPolygonsMesh GetTrianglePolygonsFromPool(GameObject receiverObject)

--- a/Assets/AirSticker/Runtime/Scripts/Core/DecalProjectorLauncher.cs
+++ b/Assets/AirSticker/Runtime/Scripts/Core/DecalProjectorLauncher.cs
@@ -56,12 +56,13 @@ namespace AirSticker.Runtime.Scripts.Core
             if (!_hasCurrentRequest) return true; // The request is empty.
 
             var projector = _currentRequest.Projector;
-            // Even if the projector is dead or the launching is canceled, its scheduled jobs may still be
-            // running, because destroying the projector stops its coroutine but not the jobs. Starting the
-            // next launch in that state corrupts the buffers the pipeline shares between launches, so the
-            // next request must wait until the jobs finish.
+            // Even if the projector is dead or the launching is canceled, its launch may still be unwinding:
+            // destroying the projector neither stops the scheduled jobs nor the async launch body, which only
+            // observes the destruction at its next resume point. Starting the next launch in that state
+            // corrupts the state the pipeline and the triangle extraction share between launches, so the next
+            // request must wait for both.
             // The C# instance is still readable after the Unity object is destroyed.
-            if (projector.IsWorkerThreadRunning) return false;
+            if (projector.IsWorkerThreadRunning || projector.IsExecutingLaunch) return false;
 
             return !projector // Projector that threw the request is dead.
                    || projector.NowState == AirStickerProjector.State.LaunchingCompleted

--- a/Assets/AirSticker/Runtime/Scripts/Core/Jobs/DecalMeshJobPipeline.cs
+++ b/Assets/AirSticker/Runtime/Scripts/Core/Jobs/DecalMeshJobPipeline.cs
@@ -12,13 +12,13 @@ namespace AirSticker.Runtime.Scripts.Core.Jobs
     ///     build. Owned by <c>AirStickerSystem</c> and reused across launches (one launch runs at a time).
     /// </summary>
     /// <remarks>
-    ///     Usage from the projector's coroutine (two async segments with a cheap main-thread step between):
+    ///     Usage from the projector's launch body (two async segments with a cheap main-thread step between):
     ///     <code>
     ///     var h1 = pipeline.ScheduleClipStage(source, ...);   // segment 1
-    ///     while (!h1.IsCompleted) yield return null; h1.Complete();
+    ///     while (!h1.IsCompleted) await Awaitable.NextFrameAsync(); h1.Complete();
     ///     pipeline.CountBuild(source, decalMeshes);           // main thread
     ///     var h2 = pipeline.ScheduleBuildStage(source, decalMeshes, ...); // segment 2
-    ///     while (!h2.IsCompleted) yield return null; h2.Complete();
+    ///     while (!h2.IsCompleted) await Awaitable.NextFrameAsync(); h2.Complete();
     ///     pipeline.ApplyToDecalMeshes(decalMeshes);           // main thread merge + (caller) upload
     ///     </code>
     /// </remarks>

--- a/Assets/AirSticker/Runtime/Scripts/Core/TrianglePolygonsFactory.cs
+++ b/Assets/AirSticker/Runtime/Scripts/Core/TrianglePolygonsFactory.cs
@@ -1,6 +1,6 @@
-using System;
-using System.Collections;
+﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using AirSticker.Runtime.Scripts.Core.Jobs;
 using Unity.Collections;
 using Unity.Mathematics;
@@ -35,7 +35,9 @@ namespace AirSticker.Runtime.Scripts.Core
         private bool _disposed;
         private static int _maxGeneratedPolygonPerFrame = 100000;
 
-        // The write cursor into the result's per-triangle SoA arrays, shared across the fill coroutines.
+        // The write cursor into the result's per-triangle SoA arrays, shared across the fill methods.
+        // Like the working buffers above it belongs to whichever extraction is running now, which is why a
+        // canceled fill must return before it writes anything (see FillFromMeshRenderersAsync).
         private int _writeTriangleCursor;
 
         /// <summary>
@@ -60,14 +62,24 @@ namespace AirSticker.Runtime.Scripts.Core
 
         /// <summary>
         ///     Build the receiver's source triangle polygons. On success the result is written to
-        ///     resultHolder[0]; it is left null if a mesh is not Read/Write enabled (nothing to build).
+        ///     resultHolder[0]; it is left null if a mesh is not Read/Write enabled (nothing to build) or if
+        ///     <paramref name="cancellation" /> was requested during the frame-sliced fill.
         /// </summary>
-        internal IEnumerator BuildFromReceiverObject(
+        /// <remarks>
+        ///     This method owns the result until it returns: the fill runs across frames and nothing can stop
+        ///     it from the outside, so it publishes the result to the holder only once it is complete and
+        ///     disposes it itself otherwise. The token is only polled, never handed to
+        ///     <c>Awaitable.NextFrameAsync</c>, because a cancelable await registers a callback on the token's
+        ///     source and would allocate on every frame of the fill.
+        /// </remarks>
+        internal async Awaitable BuildFromReceiverObjectAsync(
             IReadOnlyList<MeshRenderer> meshRenderers,
             IReadOnlyList<SkinnedMeshRenderer> skinnedMeshRenderers,
             IReadOnlyList<Terrain> terrains,
-            ReceiverConvexPolygonsMesh[] resultHolder)
+            ReceiverConvexPolygonsMesh[] resultHolder,
+            CancellationToken cancellation)
         {
+            resultHolder[0] = null;
             var numTerrainMeshPolygon = GetNumPolygonsFromTerrains(terrains, 1.0f);
             var terrainMeshResolutionScale = numTerrainMeshPolygon > 0
                 ? Mathf.Sqrt(MaxWorkingVertexCountForTerrain / (float)numTerrainMeshPolygon)
@@ -88,10 +100,6 @@ namespace AirSticker.Runtime.Scripts.Core
             var componentCount = meshRenderers.Count + skinnedMeshRenderers.Count + terrains.Count;
 
             var result = new ReceiverConvexPolygonsMesh(triangleCount, componentCount, Allocator.Persistent);
-            // Expose the freshly allocated result to the caller immediately so its OnDestroy can dispose it if
-            // the projector is destroyed during the frame-sliced fill below (which stops this coroutine before
-            // it can hand off or dispose the result itself).
-            resultHolder[0] = result;
 
             // Unify the receiver components into one global index space: mesh renderers, then skinned mesh
             // renderers, then terrains.
@@ -107,29 +115,31 @@ namespace AirSticker.Runtime.Scripts.Core
             for (var k = 0; k < terrains.Count; k++) result.ComponentByIndex[terrainBase + k] = terrains[k];
 
             _writeTriangleCursor = 0;
-            if (buildMesh) yield return FillFromMeshRenderers(meshRenderers, result);
-            if (buildSkin) yield return FillFromSkinnedMeshRenderers(skinnedMeshRenderers, skinnedBase, result);
-            yield return FillFromTerrains(terrains, terrainBase, terrainMeshResolutionScale, result);
+            if (buildMesh) await FillFromMeshRenderersAsync(meshRenderers, result, cancellation);
+            if (buildSkin && !cancellation.IsCancellationRequested)
+                await FillFromSkinnedMeshRenderersAsync(skinnedMeshRenderers, skinnedBase, result, cancellation);
+            if (!cancellation.IsCancellationRequested)
+                await FillFromTerrainsAsync(terrains, terrainBase, terrainMeshResolutionScale, result, cancellation);
 
             if (_writeTriangleCursor != triangleCount)
             {
-                // A source was destroyed during the frame-sliced fill, so the SoA is only partially written.
-                // Discard it instead of registering a mesh whose uninitialized regions the jobs would read.
-                // Clear the holder first so the caller cancels and never double-disposes this result.
-                resultHolder[0] = null;
+                // The fill was canceled, or a source was destroyed during it, so the SoA is only partially
+                // written. Discard it instead of handing over a mesh whose uninitialized regions the jobs
+                // would read. The holder is still null, so the caller cancels and never sees this result.
                 result.Dispose();
-                yield break;
+                return;
             }
 
-            // resultHolder[0] already references result (set at allocation); leave it for the caller to register.
+            resultHolder[0] = result;
         }
 
         // Driven by the mesh renderers (not the mesh filter array) so componentIndex == rendererNo always
         // matches the mesh-renderer region of ComponentByIndex, even when a child has a MeshFilter without a
         // MeshRenderer or vice versa. The polygon count (GetNumPolygonsFromMeshRenderers) is driven the same
-        // way, so the total stays consistent with BuildFromReceiverObject's completeness check.
-        private IEnumerator FillFromMeshRenderers(
-            IReadOnlyList<MeshRenderer> meshRenderers, ReceiverConvexPolygonsMesh result)
+        // way, so the total stays consistent with BuildFromReceiverObjectAsync's completeness check.
+        private async Awaitable FillFromMeshRenderersAsync(
+            IReadOnlyList<MeshRenderer> meshRenderers, ReceiverConvexPolygonsMesh result,
+            CancellationToken cancellation)
         {
             var polygonNoInFill = 0;
             for (var rendererNo = 0; rendererNo < meshRenderers.Count; rendererNo++)
@@ -155,8 +165,13 @@ namespace AirSticker.Runtime.Scripts.Core
                     {
                         if (polygonNoInFill != 0 && polygonNoInFill % MaxGeneratedPolygonPerFrame == 0)
                         {
-                            yield return null;
-                            if (!meshRenderer || !meshFilter || meshFilter.sharedMesh == null) yield break;
+                            await Awaitable.NextFrameAsync();
+                            // Checked before anything else. Unlike a coroutine this is not stopped by the
+                            // projector's destruction, and the working buffers plus _writeTriangleCursor
+                            // belong to whichever extraction is running now, so a canceled fill must return
+                            // without writing into the next launch's extraction.
+                            if (cancellation.IsCancellationRequested) return;
+                            if (!meshRenderer || !meshFilter || meshFilter.sharedMesh == null) return;
                         }
 
                         polygonNoInFill++;
@@ -172,18 +187,18 @@ namespace AirSticker.Runtime.Scripts.Core
             }
         }
 
-        private IEnumerator FillFromSkinnedMeshRenderers(
+        private async Awaitable FillFromSkinnedMeshRenderersAsync(
             IReadOnlyList<SkinnedMeshRenderer> skinnedMeshRenderers, int componentBase,
-            ReceiverConvexPolygonsMesh result)
+            ReceiverConvexPolygonsMesh result, CancellationToken cancellation)
         {
             var workingBoneWeights = _workingBoneWeights ??= new List<BoneWeight>(MaxWorkingVertexCount);
             var polygonNoInFill = 0;
             for (var rendererNo = 0; rendererNo < skinnedMeshRenderers.Count; rendererNo++)
             {
                 var skinnedMeshRenderer = skinnedMeshRenderers[rendererNo];
-                if (!skinnedMeshRenderer || skinnedMeshRenderer.sharedMesh == null) yield break;
+                if (!skinnedMeshRenderer || skinnedMeshRenderer.sharedMesh == null) return;
                 var mesh = skinnedMeshRenderer.sharedMesh;
-                if (mesh.isReadable == false) yield break;
+                if (mesh.isReadable == false) return;
                 var componentIndex = componentBase + rendererNo;
                 var hasRootBone = skinnedMeshRenderer.rootBone != null;
 
@@ -201,8 +216,9 @@ namespace AirSticker.Runtime.Scripts.Core
                     {
                         if (polygonNoInFill != 0 && polygonNoInFill % MaxGeneratedPolygonPerFrame == 0)
                         {
-                            yield return null;
-                            if (!skinnedMeshRenderer || skinnedMeshRenderer.sharedMesh == null) yield break;
+                            await Awaitable.NextFrameAsync();
+                            if (cancellation.IsCancellationRequested) return;
+                            if (!skinnedMeshRenderer || skinnedMeshRenderer.sharedMesh == null) return;
                         }
 
                         polygonNoInFill++;
@@ -221,14 +237,14 @@ namespace AirSticker.Runtime.Scripts.Core
             }
         }
 
-        private IEnumerator FillFromTerrains(
+        private async Awaitable FillFromTerrainsAsync(
             IReadOnlyList<Terrain> terrains, int componentBase, float terrainMeshResolutionScale,
-            ReceiverConvexPolygonsMesh result)
+            ReceiverConvexPolygonsMesh result, CancellationToken cancellation)
         {
             for (var terrainNo = 0; terrainNo < terrains.Count; terrainNo++)
             {
                 var terrain = terrains[terrainNo];
-                if (!terrain || terrain == null) yield break;
+                if (!terrain || terrain == null) return;
                 var componentIndex = componentBase + terrainNo;
                 var terrainData = terrain.terrainData;
                 var vertexCountW = Math.Max(2, (int)(terrainData.heightmapResolution * terrainMeshResolutionScale));
@@ -256,8 +272,9 @@ namespace AirSticker.Runtime.Scripts.Core
                 {
                     if (polygonNoInFill != 0 && polygonNoInFill % MaxGeneratedPolygonPerFrame == 0)
                     {
-                        yield return null;
-                        if (!terrain || terrain == null) yield break;
+                        await Awaitable.NextFrameAsync();
+                        if (cancellation.IsCancellationRequested) return;
+                        if (!terrain || terrain == null) return;
                     }
 
                     polygonNoInFill += 2;
@@ -348,7 +365,7 @@ namespace AirSticker.Runtime.Scripts.Core
             return numPolygon;
         }
 
-        // Renderer-driven so it stays consistent with FillFromMeshRenderers: a renderer without a MeshFilter
+        // Renderer-driven so it stays consistent with FillFromMeshRenderersAsync: a renderer without a MeshFilter
         // (or without a mesh) contributes nothing, and only a non-readable mesh aborts the whole mesh path.
         private static int GetNumPolygonsFromMeshRenderers(IReadOnlyList<MeshRenderer> meshRenderers)
         {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,18 +38,22 @@ All runtime code is in `Assets/AirSticker/Runtime/Scripts` (single asmdef `AirSt
 
 ### Projection pipeline (per launch)
 
-`AirStickerProjector.ExecuteLaunch()` is a coroutine that, per receiver object:
+`AirStickerProjector.ExecuteLaunchAsync()` is an `async Awaitable` method (started fire-and-forget by `DecalProjectorLauncher`, not a coroutine) that, per receiver object:
 
 1. Collects/creates target `DecalMesh`es from the pool (`AirStickerSystem.CollectEditDecalMeshes`). Decal renderers already hanging under the receiver are temporarily disabled so they aren't picked up as receivers themselves.
-2. Builds the triangle-polygon list via `TrianglePolygonsFactory` if not pooled — frame-sliced (`MaxGeneratedPolygonPerFrame` polygons per frame, `yield return null` between chunks) to avoid spikes. Handles `MeshFilter`, `SkinnedMeshRenderer`, and `Terrain` sources.
-3. Hands off to a **ThreadPool worker thread**: skinning matrices applied, broad-phase cull (`BroadPhaseConvexPolygonsDetection` — face-normal + distance rejection), six clip planes built from the decal box (width/height/depth in decal space), convex polygons split against them (`ConvexPolygon.SplitAndRemoveByPlane`), and resulting triangle fans appended to the decal meshes. The coroutine polls a flag until the worker finishes.
+2. Builds the triangle-polygon list via `TrianglePolygonsFactory` if not pooled — frame-sliced (`MaxGeneratedPolygonPerFrame` polygons per frame, `await Awaitable.NextFrameAsync()` between chunks) to avoid spikes. Handles `MeshFilter`, `SkinnedMeshRenderer`, and `Terrain` sources.
+3. Hands off to a **ThreadPool worker thread**: skinning matrices applied, broad-phase cull (`BroadPhaseConvexPolygonsDetection` — face-normal + distance rejection), six clip planes built from the decal box (width/height/depth in decal space), convex polygons split against them (`ConvexPolygon.SplitAndRemoveByPlane`), and resulting triangle fans appended to the decal meshes. The launch body awaits the next frame until the jobs finish.
 4. Back on the main thread, `DecalMesh.ExecutePostProcessingAfterWorkerThread()` uploads the results to Unity `Mesh` objects.
 
-`DecalMesh` spawns a child GameObject named **`"AirStickerRenderer"`** under the receiver (`DecalMeshRenderer`), with a `MeshRenderer` or `SkinnedMeshRenderer` (bones copied from the receiver) matching the source. It also carries an internal `DecalMeshRendererMarker` component, which is how `ExecuteLaunch()` filters those renderers out when gathering receiver geometry (the name itself is only for hierarchy readability — `Renderer.name` allocates, so it is not used for the check). `Assets/Demo/Demo_Benchmark` still matches on the literal name, so keep the name stable.
+`DecalMesh` spawns a child GameObject named **`"AirStickerRenderer"`** under the receiver (`DecalMeshRenderer`), with a `MeshRenderer` or `SkinnedMeshRenderer` (bones copied from the receiver) matching the source. It also carries an internal `DecalMeshRendererMarker` component, which is how `ExecuteLaunchAsync()` filters those renderers out when gathering receiver geometry (the name itself is only for hierarchy readability — `Renderer.name` allocates, so it is not used for the check). `Assets/Demo/Demo_Benchmark` still matches on the literal name, so keep the name stable.
 
 ### Constraints to keep in mind
 
 - Anything touched inside the worker-thread action must not call the Unity API — gather Unity-side data (`PrepareToRunOnWorkerThread`, bone matrices, transforms) before queueing the work item.
+- The frame-sliced work uses `UnityEngine.Awaitable`, deliberately **not** UniTask (the package must stay dependency-free) and no longer coroutines. Three rules follow from that, all of them load-bearing:
+  - Never pass a `CancellationToken` to `Awaitable.NextFrameAsync()`. A cancelable await registers a callback on the token's source, so it allocates on every frame the launch waits. Poll `destroyCancellationToken` yourself instead.
+  - An async method is **not** stopped by the projector's destruction, unlike the coroutine it replaced. Every resume point must be followed immediately by a cancellation check, before touching anything shared between launches (`TrianglePolygonsFactory`'s working buffers and write cursor, `DecalMeshJobPipeline`'s buffers) or anything `OnDestroy` has already released.
+  - Nothing awaits the launch body, so an escaping exception would be swallowed and `DecalProjectorLauncher`'s FIFO would wait forever for a state that never arrives. Keep the whole body in try/catch/finally.
 - Receiver models must have **Read/Write enabled** in import settings; the code paths that read mesh data error out otherwise (see commit history for the error-message handling).
 - Z-fighting is inherent to the technique; `zOffsetInDecalSpace` (default 0.005) is the mitigation knob.
 


### PR DESCRIPTION
## 概要

デカール貼り付けのフレーム分割処理を、コルーチンから `async`/`await` に移行しました。

公開 API（`Launch` / `NowState` / `onFinishedLaunch` / `CreateAndLaunch` / `DecalMeshes`）には元から `IEnumerator` が露出していないので、**変更は内部に閉じています**。利用者側のコード変更は不要です。

## なぜ UniTask ではなく `UnityEngine.Awaitable` か

このパッケージの売りは**依存ゼロ**（asmdef の references は Unity.Burst / Unity.Mathematics のみ）です。

- UniTask は Unity 公式レジストリ外なので `package.json` の `dependencies` に書いても解決できません。OpenUPM の `com.cysharp.unitask` を書くと、スコープ付きレジストリを設定していない利用者は **AirSticker 自体のインストールに失敗**します
- UniTask は OpenUPM / git URL / Plugins 直置き / 他アセット同梱と入り口が複数あり、二重導入で `Multiple assemblies with equivalent name 'UniTask'` になります。ライブラリ側からバージョンを固定できません
- 最小 Unity が 6000.0 なので `Awaitable` が標準で使えます
- アロケーション面でも不利ではありません。`Awaitable` も state machine box を型ごとにプールし、`Awaitable` 本体もプールへ返します

## 移行対象

| 移行前 | 移行後 |
| --- | --- |
| `AirStickerProjector.ExecuteLaunch()` | `ExecuteLaunchAsync()` |
| `AirStickerProjector.CompleteJobHandle()` | `CompleteJobHandleAsync()` |
| `AirStickerSystem.BuildTrianglePolygonsFromReceiverObject()` | `...Async()` |
| `TrianglePolygonsFactory.BuildFromReceiverObject()` + `FillFrom*` ×3 | すべて `async Awaitable` |
| `StartCoroutine(ExecuteLaunch())` | `_ = ExecuteLaunchAsync()` |

`AirStickerSystem` のファサードは `async` にせず factory の `Awaitable` をそのまま返しています（state machine の二重生成を避けるため）。`_ =` で捨てているのは `async void` を避けるためです（`async void` は `AsyncVoidMethodBuilder` を使うので state machine がプールされません）。

## 必ず守る必要があった点

### `Awaitable.NextFrameAsync()` に `CancellationToken` を渡さない

キャンセル可能な await はトークンのソースにコールバックを登録するため、**待機フレームごとに確保が発生します**。`yield return null` は元から 0 alloc だったので、素朴に `await Awaitable.NextFrameAsync(token)` にすると明確な悪化になります。`destroyCancellationToken` はローカルにキャッシュして自前でポーリングしています。

### 本体全体を try/catch/finally で囲む

戻り値の `Awaitable` を誰も await しないため、例外は観測されずに消えます。`NowState` が `Launching` のまま残ると `DecalProjectorLauncher` の FIFO が**永久に詰まります**。`catch` 内も解放処理を先に、コンテキストオブジェクト無しのログを後に置き、catch から例外が抜けないようにしています。

## コルーチンと違い破棄で止まらないことへの対応

ここが移行の本質的な難所です。`Awaitable` は projector が破棄されても止まりません。

- **await 直後の最初の文でキャンセル判定して return する。** `TrianglePolygonsFactory` のワークバッファと `_writeTriangleCursor`、`DecalMeshJobPipeline` のバッファは launch 間で共有されており、キャンセルされた本体が次の launch と同時に書き込むと壊れます
- **`IsExecutingLaunch` を追加し、launcher が本体の巻き戻り完了を待つ。** 上記の判定順に加えた二重の防御です。本体はキャンセル時も例外時も `finally` でフラグを下ろすので launcher は詰まりません
- **抽出結果の所有権を factory 側に移した。** 従来は「コルーチンが登録前に止まる」前提で `OnDestroy` が `_pendingSourceHolder` を破棄していましたが、async では**まだ書き込み中の `NativeArray` を解放する**ことになります。factory は完成品だけをホルダーに公開し、キャンセル時と不完全時は自分で `Dispose` します。`OnDestroy` はホルダーに触りません
- **使い回しリストの解放を `OnFinished` から本体の `finally` へ移した。** `OnDestroy` 経由の `OnFinished` が、抽出処理が走査中のリストを `Clear()` する競合を避けるためです

キャンセルの発生源は projector（コンポーネントまたは GameObject）の破棄だけです。launch は複数フレームにまたがるので、短命なオブジェクトに projector を載せる使い方、シーン遷移、プレイモード終了で踏みます。receiver の破棄や Read/Write 無効は従来どおり別のチェックで処理しています。

## 副産物として直ったもの

- **`SetActive(false)` で FIFO が永久に詰まる問題が解消します。** コルーチンは停止して `NowState` が `Launching` のまま残りましたが、`Awaitable` は停止せず完了まで進みます
- `OnFinished` で `NowState` の設定をコールバック呼び出しの**前**に移しました。リスナーが例外を投げると `NowState` が `Launching` のまま残り FIFO が詰まります。既存の穴ですが、詰まりを避けるという今回の主題に直結するため直しました。リスナーは状態を引数で受け取るので、観測できる情報は変わりません

## GC.Alloc について（未計測）

1 launch あたりの反復子が**約8個から約1個**になる見込みです（誰も await しないトップレベルの `Awaitable` はプールに返らないため1個残ります）。ただし**数百 B/launch のオーダーで、すでに潰した 145.8 KB（#41）/ 5.1 KB（#40）とは桁が2〜3つ違います**。

待機フレームあたりは移行前後どちらも 0 です。ここは改善ではなく**悪化させないことが要件**でした。

**この移行の主な価値は GC ではなく、上記の詰まり解消と破棄時の所有権の明示化です。**

## 確認したこと

- `AirSticker.csproj` / `Tests.csproj` / `Assembly-CSharp.csproj` を MSBuild でビルドし、エラー・新規警告なし。

## 未確認（レビュー前に実施が必要）

コンパイル以外は未検証です。以下の確認をお願いします。

- 通常の貼り付け（Demo_01 / 02 / 03）と、同じ receiver への貼り重ね
- **貼り付け途中での projector 破棄** — `MaxGeneratedPolygonPerFrame` を小さくして抽出を長くすると踏みやすい
- **貼り付け途中での receiver 削除**
- **デカール連射** — FIFO が詰まらないこと
- **`SetActive(false)` からの復帰** — 従来詰まっていた経路
- シーン遷移・プレイモード終了を貼り付け中に行う
- EditMode テスト4本
- Profiler で 1 launch の GC.Alloc を前後比較（**2回目以降の launch で測ること**。初回は state machine box のプール確保が入るため、移行後のほうが多く見える可能性があります）

## 対象外

`README_DEVELOPERS.md` / `_JA.md` のコード例にも `yield return null` が残っていますが、これは Job System 移行前の実装（`ConvexPolygonInfo` 等）を説明したもので既に現状と乖離しています。アルゴリズム解説の書き直しになり EN/JA 両方の同期も必要なので、別作業として切り出すのが妥当と判断しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
