### PR TITLE
Air Sticker 2.2.0 リリース準備

### DIFF
--- a/Assets/AirSticker/CHANGELOG.md
+++ b/Assets/AirSticker/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this package are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2026-08-12
+
+Decal projection allocates far less on the managed heap, and the frame-sliced projection now
+runs on `UnityEngine.Awaitable` instead of coroutines. The public API is unchanged, so this is
+a drop-in update.
+
+### Changed
+
+- Pasting a decal no longer produces per-frame GC allocations, and the per-launch allocations
+  are largely gone. Measured on the demo scenes: 320 B every frame while the system was idle,
+  5.1 KB on the frame a launch starts, and 145.8 KB on the frame it finishes are all removed.
+  The last one also grew quadratically when decals were pasted onto the same receiver
+  repeatedly, because the CPU-side vertex buffers were reallocated to the exact new length on
+  every append; they are now `NativeArray`s with doubling capacity.
+- The frame-sliced projection uses `UnityEngine.Awaitable` instead of coroutines. No new
+  package dependency is introduced (`Awaitable` is part of Unity 6.0, this package's minimum).
+- **A projector that is disabled mid-launch now keeps projecting.** Previously the launch was
+  a coroutine, so disabling the projector's GameObject (or the component) stopped it where it
+  was and it never resumed. If your code relies on `SetActive(false)` to hold a launch back,
+  destroy the projector instead. Destroying it still cancels the launch as before.
+
+### Fixed
+
+- Disabling a projector while it was launching stalled every later decal: the projector stayed
+  in the `Launching` state forever, and `DecalProjectorLauncher` runs one launch at a time, so
+  its queue never advanced. The same stall happened when an `onFinishedLaunch` listener threw,
+  because the state was published only after the callback returned.
+
 ## [2.1.0] - 2026-08-03
 
 ### Added

--- a/Assets/AirSticker/package.json
+++ b/Assets/AirSticker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jp.co.cyberagent.air-sticker",
   "displayName": "Air Sticker",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "unity": "6000.0",
   "license": "MIT",
   "dependencies": {

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Or, open `Packages/manifest.json` and add the following to the dependencies bloc
 
 If you want to set the target version, write as follows.
 
-* https://github.com/CyberAgentGameEntertainment/AirSticker.git?path=/Assets/AirSticker#2.1.0
+* https://github.com/CyberAgentGameEntertainment/AirSticker.git?path=/Assets/AirSticker#2.2.0
 
 Note that if you get a message like `No 'git' executable was found. Please install Git on your system and restart Unity`, you will need to set up Git on your machine.
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -112,7 +112,7 @@ Air Stickerはメッシュ生成に数フレームかかりますが、描画パ
 
 バージョンを指定したい場合には以下のように記述します。
 
-* https://github.com/CyberAgentGameEntertainment/AirSticker.git?path=/Assets/AirSticker#2.1.0
+* https://github.com/CyberAgentGameEntertainment/AirSticker.git?path=/Assets/AirSticker#2.2.0
 
 なお`No 'git' executable was found. Please install Git on your system and restart Unity`のようなメッセージが出た場合、マシンにGitをセットアップする必要がある点にご注意ください。
 


### PR DESCRIPTION
## 概要

Air Sticker 2.2.0 のリリース準備です。過去のリリース（#38）と同じ3点セットの変更のみで、ライブラリのコードは変更していません。

| ファイル | 変更 |
| --- | --- |
| `Assets/AirSticker/package.json` | `2.1.0` → `2.2.0` |
| `Assets/AirSticker/CHANGELOG.md` | `[2.2.0] - 2026-08-12` エントリを追加 |
| `README.md` / `README_JA.md` | バージョン指定インストール例を `#2.2.0` へ |

## 2.1.0 からの内容

| PR | 内容 |
| --- | --- |
| #39 | 毎フレーム発生していた 320B の GC.Alloc を削除 |
| #40 | launch 開始フレームの 5.1KB を削除 |
| #41 | 仕上げフレームの 145.8KB を削除。貼り重ね時の二次オーダーも解消 |
| #42 | フレーム分割処理をコルーチンから `UnityEngine.Awaitable` に移行 |

## なぜマイナーバンプか

**公開 API は変更されていません**（`AirStickerSystem` / `AirStickerProjector` のシグネチャ、`NowState`、`onFinishedLaunch`、`CreateAndLaunch` すべて同一）。パッチではなくマイナーにしたのは、#42 に**利用者から観測できる挙動変更**が含まれるためです。

- **貼り付け中に projector を無効化しても投影が進むようになりました。** 従来は launch がコルーチンだったため、GameObject（またはコンポーネント）を無効化すると停止したまま再開しませんでした。`SetActive(false)` で launch を止める使い方をしている場合は、破棄に変更する必要があります。破棄は従来どおりキャンセルとして機能します

この挙動変更は CHANGELOG の `Changed` に太字で記載しています。

## CHANGELOG に `Fixed` を立てた理由

上記の無効化による停止は、単に「止まる」だけでなく**以降のデカールすべてが貼れなくなる**不具合でした。`NowState` が `Launching` のまま残り、`DecalProjectorLauncher` は一度に1つの launch しか走らせないため、キューが二度と進みません。`onFinishedLaunch` のリスナーが例外を投げた場合も（状態の公開がコールバック後だったため）同じ詰まりが起きていました。どちらも #42 で解消しています。

## 確認したこと

- `Assets/AirSticker/package.json` 以外にバージョン文字列の残りがないことを確認（`README.md` / `README_JA.md` の `#2.1.0` は両方更新済み、EN/JA 同期）。
- `origin/main`（`c4a8169`、#42 マージ済み）にリベースしてあり、差分はこの4ファイルのみです。
- ライブラリのコードは無変更なので、ビルド・動作への影響はありません。

## マージ後

`2.2.0` タグの作成が必要です（利用者は `?path=/Assets/AirSticker#2.2.0` で参照するため）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
